### PR TITLE
Add Force Extended Info option

### DIFF
--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Foundation -->
 <window id="2003">
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + [Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)]">Action(close)</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(movies) + Skin.String(ListItem.IMDBNumber)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],imdb_id=$INFO[ListItem.IMDBNumber],name=$INFO[ListItem.Title])</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(movies) + !Skin.String(ListItem.IMDBNumber)">RunScript(script.extendedinfo,info=extendedinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.Title])</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(tvshows) + Skin.String(ListItem.IMDBNumber)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],tvdb_id=$INFO[ListItem.IMDBNumber],name=$INFO[ListItem.TVShowTitle])</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(tvshows) + !Skin.String(ListItem.IMDBNumber)">RunScript(script.extendedinfo,info=extendedtvinfo,dbid=$INFO[ListItem.DBID],name=$INFO[ListItem.TVShowTitle])</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(seasons)">RunScript(script.extendedinfo,info=seasoninfo,tvshow=$INFO[ListItem.TVShowTitle],dbid=$INFO[ListItem.DBID],season=$INFO[ListItem.Season])</onload>
+    <onload condition="Skin.HasSetting(ExtendedInfoDefault) + System.HasAddon(script.extendedinfo) + Container.Content(episodes)">RunScript(script.extendedinfo,info=extendedepisodeinfo,tvshow=$INFO[ListItem.TVShowTitle],dbid=$INFO[ListItem.DBID],episode=$INFO[ListItem.Episode],season=$INFO[ListItem.Season])</onload>
+
     <defaultcontrol always="true">9570</defaultcontrol>
     <onload>ClearProperty(TrailerPlaying,Home)</onload>
     <onunload>ClearProperty(TrailerPlaying,Home)</onunload>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -230,6 +230,14 @@
                             <onclick condition="!String.IsEmpty(Skin.String(MenuPos))">Skin.Reset(MenuPos)</onclick>
                         </control>
 
+                        <control type="radiobutton" id="9110" description="Open Extended Info by Default">
+                            <visible>Integer.IsEqual(Window.Property(CurrentFocus),9001)</visible>
+                            <include>Defs_Settings_Button</include>
+                            <label>$LOCALIZE[31393]</label>
+                            <selected>Skin.HasSetting(ForceExtendedInfo)</selected>
+                            <onclick>Skin.ToggleSetting(ForceExtendedInfo)</onclick>
+                        </control>
+
                         <!-- ========== -->
                         <!-- Background -->
                         <!-- ========== -->

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1868,3 +1868,8 @@ msgstr ""
 msgctxt "#31392"
 msgid "Sort Letter"
 msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31393"
+msgid "Force open Extended Info"
+msgstr ""+


### PR DESCRIPTION
This simple pull request adds an option in Skin Settings to allow the user to force EIS/EIM/Wraith to open, in place of the default information window.

There is a strange bug on the home window, where if information is opened from a widget item, the window position resets to the first view before opening the extended info window. I haven't been able to figure out what's causing it, but maybe you can help me track it down?