### PR TITLE
Fix typos in translation & add en_us

### DIFF
--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -117,7 +117,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31021"
-msgid "Colors"
+msgid "Colours"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -207,7 +207,7 @@ msgstr ""
 
 #: /1080i/Custom_1117_EnableViews.xml
 msgctxt "#31039"
-msgid "Enable / disable viewmodes"
+msgid "Enable / disable view modes"
 msgstr ""
 
 #: /1080i/Custom_1117_EnableViews.xml
@@ -277,12 +277,12 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31053"
-msgid "Display discart in showcase viewtypes. Available discart overrides logo if both options are enabled."
+msgid "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31054"
-msgid "Display logo in showcase viewtypes. Available discart overrides logo if both options are enabled."
+msgid "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -292,7 +292,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31056"
-msgid "Genre colors in PVR guide"
+msgid "Genre colours in PVR guide"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -312,7 +312,7 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31060"
-msgid "Set a music or video playlist that will run when kodi starts."
+msgid "Set music or video playlist that will run when Kodi starts."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -332,7 +332,7 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31064"
-msgid "Backup your skin settings and home menu shortcuts to a zipfile. Useful to migrate settings to a new setup."
+msgid "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -347,7 +347,7 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31067"
-msgid "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any kodi system settings."
+msgid "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
 msgstr ""
 
 #: /1080i/Includes_Weather.xml
@@ -397,7 +397,7 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31077"
-msgid "Add a slight transparency to the top and bottom bars."
+msgid "Add slight transparency to the top and bottom bars."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -457,7 +457,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31089"
-msgid "Position context menu based on focused item"
+msgid "Position context menu based on the focused item"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -512,7 +512,7 @@ msgstr ""
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31100"
-msgid "Processor, Memory and Video"
+msgid "Processor, Memory, and Video"
 msgstr ""
 
 msgctxt "#31101"
@@ -556,7 +556,7 @@ msgid "Background"
 msgstr ""
 
 msgctxt "#31111"
-msgid "Display now playing video in background"
+msgid "Display now playing video in the background"
 msgstr ""
 
 msgctxt "#31112"
@@ -699,7 +699,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31145"
-msgid "Display poster and plot when video is paused"
+msgid "Display poster and plot when a video is paused"
 msgstr ""
 
 msgctxt "#31146"
@@ -739,7 +739,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31154"
-msgid "Only use blur in info dialog"
+msgid "Only use blur in the info dialog"
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -749,12 +749,12 @@ msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31156"
-msgid "Apply a color changing overlay effect to music visualisation background."
+msgid "Apply a colour changing overlay effect to music visualisation background."
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31157"
-msgid "A scrolling text effect showing artist, album and song info overlayed on the music visualisation background."
+msgid "A scrolling text effect showing artist, album and song info overlaid on the music visualisation background."
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -824,7 +824,7 @@ msgid "Video Extras"
 msgstr ""
 
 msgctxt "#31172"
-msgid "Display music visualisation in background"
+msgid "Display music visualisation in the background"
 msgstr ""
 
 msgctxt "#31173"
@@ -888,7 +888,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31186"
-msgid "Display osd submenu"
+msgid "Display OSD submenu"
 msgstr ""
 
 msgctxt "#31187"
@@ -919,7 +919,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31193"
-msgid "Reset colors to default"
+msgid "Reset colours to default"
 msgstr ""
 
 #: /shortcuts/overrides.xml
@@ -998,7 +998,7 @@ msgid "Popular"
 msgstr ""
 
 msgctxt "#31211"
-msgid "Top Rated"
+msgid "Top-Rated"
 msgstr ""
 
 msgctxt "#31212"
@@ -1049,7 +1049,7 @@ msgstr ""
 
 #: /shortcuts/overrides.xml
 msgctxt "#31222"
-msgid "Top Rated TV Shows"
+msgid "Top-Rated TV Shows"
 msgstr ""
 
 msgctxt "#31223"
@@ -1061,7 +1061,7 @@ msgid "Popular Movies"
 msgstr ""
 
 msgctxt "#31225"
-msgid "Top Rated Movies"
+msgid "Top-Rated Movies"
 msgstr ""
 
 msgctxt "#31226"
@@ -1069,11 +1069,11 @@ msgid "Popular TV Shows"
 msgstr ""
 
 msgctxt "#31227"
-msgid "Top Rated TV Shows"
+msgid "Top-Rated TV Shows"
 msgstr ""
 
 msgctxt "#31228"
-msgid "On Air TV Shows"
+msgid "On-Air TV Shows"
 msgstr ""
 
 msgctxt "#31229"
@@ -1082,7 +1082,7 @@ msgstr ""
 
 #: /shortcuts/overrides.xml
 msgctxt "#31230"
-msgid "Top Rated Episodes"
+msgid "Top-Rated Episodes"
 msgstr ""
 
 #: /1080i/Includes_View_Posters.xml
@@ -1154,12 +1154,12 @@ msgstr ""
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31245"
-msgid "Customize"
+msgid "Customise"
 msgstr ""
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31246"
-msgid "Press right to customize widgets"
+msgid "Press right to customise widgets"
 msgstr ""
 
 #: /1080i/script-skinshortcuts.xml
@@ -1174,7 +1174,7 @@ msgstr ""
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31249"
-msgid "Press right to customize shortcuts"
+msgid "Press right to customise shortcuts"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -1192,7 +1192,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31253"
-msgid "Use larger font for progress bar"
+msgid "Use a larger font for the progress bar"
 msgstr ""
 
 #: /1080i/script-skinshortcuts.xml
@@ -1279,7 +1279,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31273"
-msgid "Background overlay color"
+msgid "Background overlay colour"
 msgstr ""
 
 #: /shortcuts/overrides.xml
@@ -1348,7 +1348,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31288"
-msgid "Match highlight colors with poster"
+msgid "Match highlight colours with the poster"
 msgstr ""
 
 msgctxt "#31289"
@@ -1366,7 +1366,7 @@ msgstr ""
 
 #: /1080i/DialogBusy.xml
 msgctxt "#31292"
-msgid "Kodi is busy$COMMA one moment please"
+msgid "Kodi is busy$COMMA one moment, please"
 msgstr ""
 
 #: /shortcuts/overrides.xml
@@ -1431,7 +1431,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31305"
-msgid "Color cycling"
+msgid "Colour cycling"
 msgstr ""
 
 #: /1080i/Includes_Items.xml
@@ -1476,7 +1476,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31314"
-msgid "Automatically display music video info at beginning and end of clip"
+msgid "Automatically display music video info at the beginning and end of a clip"
 msgstr ""
 
 #: /1080i/Includes_Home.xml
@@ -1581,7 +1581,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31335"
-msgid "Match background overlay color with poster"
+msgid "Match background overlay colour with the poster"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -1726,7 +1726,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31364"
-msgid "Mouse compatability"
+msgid "Mouse compatibility"
 msgstr ""
 
 #: /1080i/script-script.extendedinfo-DialogVideoInfo.xml
@@ -1801,7 +1801,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31379"
-msgid "Display plot overlay after delay"
+msgid "Display plot overlay after a delay"
 msgstr ""
 
 #: /1080i/Includes_Labels.xml
@@ -1836,7 +1836,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31386"
-msgid "Auto close OSD controls after delay (in seconds)"
+msgid "Auto close OSD controls after a delay (in seconds)"
 msgstr ""
 
 #: /1080i/SkinSettings.xml
@@ -1956,7 +1956,7 @@ msgstr ""
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31410"
-msgid "Show trailers and special features in preview window"
+msgid "Show trailers and special features in the preview window"
 msgstr ""
 
 #: /1080i/Includes_Weather.xml

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -7,7 +7,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
+"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: /1080i/Includes_Global.xml

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -13,1953 +13,1953 @@ msgstr ""
 #: /1080i/Includes_Global.xml
 msgctxt "#31000"
 msgid "Reduced"
-msgstr ""
+msgstr "Reduced"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31001"
 msgid "Revenue"
-msgstr ""
+msgstr "Revenue"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31002"
 msgid "Categories widget"
-msgstr ""
+msgstr "Categories widget"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31003"
 msgid "Current conditions"
-msgstr ""
+msgstr "Current conditions"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31004"
 msgid "Sunset at"
-msgstr ""
+msgstr "Sunset at"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31005"
 msgid "Sunrise at"
-msgstr ""
+msgstr "Sunrise at"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31006"
 msgid "Weather provided by"
-msgstr ""
+msgstr "Weather provided by"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31007"
 msgid "Weather forecast for"
-msgstr ""
+msgstr "Weather forecast for"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31008"
 msgid "Install weather fanart"
-msgstr ""
+msgstr "Install weather fanart"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31009"
 msgid "Complete"
-msgstr ""
+msgstr "Complete"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31010"
 msgid "Weather fanart successfully installed"
-msgstr ""
+msgstr "Weather fanart successfully installed"
 
 #: /1080i/MyWeather.xml
 msgctxt "#31011"
 msgid "Default weather icons"
-msgstr ""
+msgstr "Default weather icons"
 
 #: /1080i/MyWeather.xml
 msgctxt "#31012"
 msgid "Weather fanart installed"
-msgstr ""
+msgstr "Weather fanart installed"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31013"
 msgid "Set weather icons"
-msgstr ""
+msgstr "Set weather icons"
 
 #: /1080i/MyVideoNav.xml
 msgctxt "#31014"
 msgid "Extra fanart"
-msgstr ""
+msgstr "Extra fanart"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31015"
 msgid "Minimal busy loader"
-msgstr ""
+msgstr "Minimal busy loader"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31016"
 msgid "By"
-msgstr ""
+msgstr "By"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31017"
 msgid "Smart Shortcuts"
-msgstr ""
+msgstr "Smart Shortcuts"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31018"
 msgid "Common Shortcut"
-msgstr ""
+msgstr "Common Shortcut"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31019"
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31020"
 msgid "mins"
-msgstr ""
+msgstr "mins"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31021"
 msgid "Colours"
-msgstr ""
+msgstr "Colours"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31022"
 msgid "Animated artwork"
-msgstr ""
+msgstr "Animated artwork"
 
 #: /1080i/Includes_Statusbar.xml
 msgctxt "#31023"
 msgid "Fullscreen"
-msgstr ""
+msgstr "Fullscreen"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31024"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Miscellaneous"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31025"
 msgid "From"
-msgstr ""
+msgstr "From"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31026"
 msgid "Alphabet strip"
-msgstr ""
+msgstr "Alphabet strip"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31027"
 msgid "Customise power menu"
-msgstr ""
+msgstr "Customise power menu"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31028"
 msgid "Reset skin settings to defaults (WARNING: This will reset your home menu to skin defaults)"
-msgstr ""
+msgstr "Reset skin settings to defaults (WARNING: This will reset your home menu to skin defaults)"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31029"
 msgid "Hide Spoilers"
-msgstr ""
+msgstr "Hide Spoilers"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31030"
 msgid "Backup / Restore"
-msgstr ""
+msgstr "Backup / Restore"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31031"
 msgid "Backup skin settings"
-msgstr ""
+msgstr "Backup skin settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31032"
 msgid "Restore skin settings"
-msgstr ""
+msgstr "Restore skin settings"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31033"
 msgid "Audio Settings"
-msgstr ""
+msgstr "Audio Settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31034"
 msgid "Change backup and restore path"
-msgstr ""
+msgstr "Change backup and restore path"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31035"
 msgid "hrs"
-msgstr ""
+msgstr "hrs"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31036"
 msgid "hr"
-msgstr ""
+msgstr "hr"
 
 #: /1080i/DialogSubtitles.xml
 msgctxt "#31037"
 msgid "Download Subtitles"
-msgstr ""
+msgstr "Download Subtitles"
 
 #: /1080i/Includes_View.xml
 msgctxt "#31038"
 msgid "Landscape"
-msgstr ""
+msgstr "Landscape"
 
 #: /1080i/Custom_1117_EnableViews.xml
 msgctxt "#31039"
 msgid "Enable / disable view modes"
-msgstr ""
+msgstr "Enable / disable view modes"
 
 #: /1080i/Custom_1117_EnableViews.xml
 msgctxt "#31040"
 msgid "Poster Showcase"
-msgstr ""
+msgstr "Poster Showcase"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31041"
 msgid "Customise your home menu items, widgets, and backgrounds."
-msgstr ""
+msgstr "Customise your home menu items, widgets, and backgrounds."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31042"
 msgid "Wall view text labels"
-msgstr ""
+msgstr "Wall view text labels"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31043"
 msgid "Select Action"
-msgstr ""
+msgstr "Select Action"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31044"
 msgid "Search library for movies staring"
-msgstr ""
+msgstr "Search library for movies staring"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31045"
 msgid "Show extended info about"
-msgstr ""
+msgstr "Show extended info about"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31046"
 msgid "Search library"
-msgstr ""
+msgstr "Search library"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31047"
 msgid "This disables fanart in the library and shows the fallback image instead."
-msgstr ""
+msgstr "This disables fanart in the library and shows the fallback image instead."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31048"
 msgid "Set a fallback image for when no fanart is available."
-msgstr ""
+msgstr "Set a fallback image for when no fanart is available."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31049"
 msgid "Display artist fanart stored from the library database on the music visualisation screen."
-msgstr ""
+msgstr "Display artist fanart stored from the library database on the music visualisation screen."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31050"
 msgid "Use artist slideshow addon to display artist fanart on the music visualisation screen."
-msgstr ""
+msgstr "Use artist slideshow addon to display artist fanart on the music visualisation screen."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31051"
 msgid "Make the artist fanart slightly transparent so that the music visualisation shows through."
-msgstr ""
+msgstr "Make the artist fanart slightly transparent so that the music visualisation shows through."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31052"
 msgid "Use a pan and zoom effect on the artist fanart in the music visualisation."
-msgstr ""
+msgstr "Use a pan and zoom effect on the artist fanart in the music visualisation."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31053"
 msgid "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
-msgstr ""
+msgstr "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31054"
 msgid "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
-msgstr ""
+msgstr "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31055"
 msgid "Use skinhelper to provide animated posters and fanart. These can be downloaded from the context menu."
-msgstr ""
+msgstr "Use skinhelper to provide animated posters and fanart. These can be downloaded from the context menu."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31056"
 msgid "Genre colours in PVR guide"
-msgstr ""
+msgstr "Genre colours in PVR guide"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31057"
 msgid "Use fullscreen PVR guide (hide plot info)"
-msgstr ""
+msgstr "Use fullscreen PVR guide (hide plot info)"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31058"
 msgid "Change the highlight focus colour used throughout the skin."
-msgstr ""
+msgstr "Change the highlight focus colour used throughout the skin."
 
 #: /1080i/DialogContextMenu.xml
 msgctxt "#31059"
 msgid "Context Menu"
-msgstr ""
+msgstr "Context Menu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31060"
 msgid "Set music or video playlist that will run when Kodi starts."
-msgstr ""
+msgstr "Set music or video playlist that will run when Kodi starts."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31061"
 msgid "Disable the alphabet strip and always use scrollbars instead."
-msgstr ""
+msgstr "Disable the alphabet strip and always use scrollbars instead."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31062"
 msgid "Disable changing view settings and some settings buttons in information dialogs."
-msgstr ""
+msgstr "Disable changing view settings and some settings buttons in information dialogs."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31063"
 msgid "Change the items displayed in the power menu."
-msgstr ""
+msgstr "Change the items displayed in the power menu."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31064"
 msgid "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
-msgstr ""
+msgstr "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31065"
 msgid "Restore your skin settings, shortcuts, and widgets from a backup file."
-msgstr ""
+msgstr "Restore your skin settings, shortcuts, and widgets from a backup file."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31066"
 msgid "Change the location where skin backup files are saved."
-msgstr ""
+msgstr "Change the location where skin backup files are saved."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31067"
 msgid "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
-msgstr ""
+msgstr "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31068"
 msgid "Cloud cover"
-msgstr ""
+msgstr "Cloud cover"
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31069"
 msgid "Cloud cover is "
-msgstr ""
+msgstr "Cloud cover is "
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31070"
 msgid "Cloud Cover"
-msgstr ""
+msgstr "Cloud Cover"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31071"
 msgid "IMDB Top250"
-msgstr ""
+msgstr "IMDB Top250"
 
 #: /1080i/DialogButtonMenu.xml
 msgctxt "#31072"
 msgid "Power Menu"
-msgstr ""
+msgstr "Power Menu"
 
 #: /1080i/VideoOSD.xml
 msgctxt "#31073"
 msgid "Recommended Youtube Videos"
-msgstr ""
+msgstr "Recommended Youtube Videos"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31074"
 msgid "Make bottom bar transparent"
-msgstr ""
+msgstr "Make bottom bar transparent"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31075"
 msgid "Apply transparency to bottom bar"
-msgstr ""
+msgstr "Apply transparency to bottom bar"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31076"
 msgid "Enable transparency"
-msgstr ""
+msgstr "Enable transparency"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31077"
 msgid "Add slight transparency to the top and bottom bars."
-msgstr ""
+msgstr "Add slight transparency to the top and bottom bars."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31078"
 msgid "Ended"
-msgstr ""
+msgstr "Ended"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31079"
 msgid "Pause video when opening extended info"
-msgstr ""
+msgstr "Pause video when opening extended info"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31080"
 msgid "Artwork button downloads all available artwork (as specified in artwork downloader settings)"
-msgstr ""
+msgstr "Artwork button downloads all available artwork (as specified in artwork downloader settings)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31081"
 msgid "Hide plot"
-msgstr ""
+msgstr "Hide plot"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31082"
 msgid "Video process information"
-msgstr ""
+msgstr "Video process information"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31083"
 msgid "Framerate"
-msgstr ""
+msgstr "Framerate"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31084"
 msgid "Aspect Ratio"
-msgstr ""
+msgstr "Aspect Ratio"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31085"
 msgid "Codec Info"
-msgstr ""
+msgstr "Codec Info"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31086"
 msgid "Extended Info"
-msgstr ""
+msgstr "Extended Info"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31087"
 msgid "Colour overlay effect"
-msgstr ""
+msgstr "Colour overlay effect"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31088"
 msgid "Scrolling text effect"
-msgstr ""
+msgstr "Scrolling text effect"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31089"
 msgid "Position context menu based on the focused item"
-msgstr ""
+msgstr "Position context menu based on the focused item"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31090"
 msgid "Display duration format as X HRS XX MINS"
-msgstr ""
+msgstr "Display duration format as X HRS XX MINS"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31091"
 msgid "Prefer list view for seasons"
-msgstr ""
+msgstr "Prefer list view for seasons"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31092"
 msgid "System Name"
-msgstr ""
+msgstr "System Name"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31093"
 msgid "Gateway Address"
-msgstr ""
+msgstr "Gateway Address"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31094"
 msgid "Network and Storage"
-msgstr ""
+msgstr "Network and Storage"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31095"
 msgid "Video Encoder"
-msgstr ""
+msgstr "Video Encoder"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31096"
 msgid "Memory"
-msgstr ""
+msgstr "Memory"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31097"
 msgid "Fan Speed"
-msgstr ""
+msgstr "Fan Speed"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31098"
 msgid "CPU Info"
-msgstr ""
+msgstr "CPU Info"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31099"
 msgid "CPU Usage"
-msgstr ""
+msgstr "CPU Usage"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31100"
 msgid "Processor, Memory, and Video"
-msgstr ""
+msgstr "Processor, Memory, and Video"
 
 msgctxt "#31101"
 msgid "items"
-msgstr ""
+msgstr "items"
 
 msgctxt "#31102"
 msgid "min"
-msgstr ""
+msgstr "min"
 
 msgctxt "#31103"
 msgid "Live TV"
-msgstr ""
+msgstr "Live TV"
 
 msgctxt "#31104"
 msgid "Used Memory"
-msgstr ""
+msgstr "Used Memory"
 
 msgctxt "#31105"
 msgid "Spotlight"
-msgstr ""
+msgstr "Spotlight"
 
 msgctxt "#31106"
 msgid "Ends "
-msgstr ""
+msgstr "Ends "
 
 msgctxt "#31107"
 msgid "Video Stream"
-msgstr ""
+msgstr "Video Stream"
 
 msgctxt "#31108"
 msgid "Current Menu"
-msgstr ""
+msgstr "Current Menu"
 
 msgctxt "#31109"
 msgid "Customise home menu"
-msgstr ""
+msgstr "Customise home menu"
 
 msgctxt "#31110"
 msgid "Background"
-msgstr ""
+msgstr "Background"
 
 msgctxt "#31111"
 msgid "Display now playing video in the background"
-msgstr ""
+msgstr "Display now playing video in the background"
 
 msgctxt "#31112"
 msgid "Submenu"
-msgstr ""
+msgstr "Submenu"
 
 msgctxt "#31113"
 msgid "No Timer"
-msgstr ""
+msgstr "No Timer"
 
 msgctxt "#31114"
 msgid "Now Playing"
-msgstr ""
+msgstr "Now Playing"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31115"
 msgid "Recommended"
-msgstr ""
+msgstr "Recommended"
 
 msgctxt "#31116"
 msgid "DVD Menu"
-msgstr ""
+msgstr "DVD Menu"
 
 msgctxt "#31117"
 msgid "3D Mode"
-msgstr ""
+msgstr "3D Mode"
 
 msgctxt "#31118"
 msgid "Artist slideshow"
-msgstr ""
+msgstr "Artist slideshow"
 
 msgctxt "#31119"
 msgid "Visualisation behind slideshow"
-msgstr ""
+msgstr "Visualisation behind slideshow"
 
 msgctxt "#31120"
 msgid "Animate artist slideshow"
-msgstr ""
+msgstr "Animate artist slideshow"
 
 msgctxt "#31121"
 msgid "Fanart"
-msgstr ""
+msgstr "Fanart"
 
 msgctxt "#31122"
 msgid "Ongoing Episodes"
-msgstr ""
+msgstr "Ongoing Episodes"
 
 msgctxt "#31123"
 msgid "Resumable Movies"
-msgstr ""
+msgstr "Resumable Movies"
 
 msgctxt "#31124"
 msgid "Recent Movies"
-msgstr ""
+msgstr "Recent Movies"
 
 msgctxt "#31125"
 msgid "Recent Episodes"
-msgstr ""
+msgstr "Recent Episodes"
 
 msgctxt "#31126"
 msgid "Episodes Spotlight"
-msgstr ""
+msgstr "Episodes Spotlight"
 
 msgctxt "#31127"
 msgid "Movies Spotlight"
-msgstr ""
+msgstr "Movies Spotlight"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31128"
 msgid "Allow scrolling through items when in full fanart mode"
-msgstr ""
+msgstr "Allow scrolling through items when in full fanart mode"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31129"
 msgid "Enable full fanart mode"
-msgstr ""
+msgstr "Enable full fanart mode"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31130"
 msgid "Media flags"
-msgstr ""
+msgstr "Media flags"
 
 #: /1080i/MusicOSD.xml
 msgctxt "#31131"
 msgid "Colour overlay"
-msgstr ""
+msgstr "Colour overlay"
 
 msgctxt "#31132"
 msgid "Reset home menu shortcuts to defaults"
-msgstr ""
+msgstr "Reset home menu shortcuts to defaults"
 
 msgctxt "#31133"
 msgid "Hide watched"
-msgstr ""
+msgstr "Hide watched"
 
 msgctxt "#31134"
 msgid "Trending Movies"
-msgstr ""
+msgstr "Trending Movies"
 
 msgctxt "#31135"
 msgid "Trending Shows"
-msgstr ""
+msgstr "Trending Shows"
 
 msgctxt "#31136"
 msgid "Airing Shows"
-msgstr ""
+msgstr "Airing Shows"
 
 msgctxt "#31137"
 msgid "Premiering Shows"
-msgstr ""
+msgstr "Premiering Shows"
 
 msgctxt "#31138"
 msgid "Content Loading"
-msgstr ""
+msgstr "Content Loading"
 
 msgctxt "#31139"
 msgid "Box Office"
-msgstr ""
+msgstr "Box Office"
 
 msgctxt "#31140"
 msgid "Budget"
-msgstr ""
+msgstr "Budget"
 
 msgctxt "#31141"
 msgid "Youtube"
-msgstr ""
+msgstr "Youtube"
 
 #: /1080i/MusicOSD.xml
 msgctxt "#31142"
 msgid "Scrolling text"
-msgstr ""
+msgstr "Scrolling text"
 
 msgctxt "#31143"
 msgid "Set weather fanart"
-msgstr ""
+msgstr "Set weather fanart"
 
 msgctxt "#31144"
 msgid "Edit Widgets"
-msgstr ""
+msgstr "Edit Widgets"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31145"
 msgid "Display poster and plot when a video is paused"
-msgstr ""
+msgstr "Display poster and plot when a video is paused"
 
 msgctxt "#31146"
 msgid "Animate fanart"
-msgstr ""
+msgstr "Animate fanart"
 
 msgctxt "#31147"
 msgid "Extra Info"
-msgstr ""
+msgstr "Extra Info"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31148"
 msgid "Hide artwork"
-msgstr ""
+msgstr "Hide artwork"
 
 msgctxt "#31149"
 msgid "Replace widget fanart with background"
-msgstr ""
+msgstr "Replace widget fanart with background"
 
 msgctxt "#31150"
 msgid "Set fallback image"
-msgstr ""
+msgstr "Set fallback image"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31151"
 msgid "Hide tvshow labels"
-msgstr ""
+msgstr "Hide tvshow labels"
 
 msgctxt "#31152"
 msgid "Furniture"
-msgstr ""
+msgstr "Furniture"
 
 #: /1080i/Includes_Statusbar.xml
 msgctxt "#31153"
 msgid "Sort by:"
-msgstr ""
+msgstr "Sort by:"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31154"
 msgid "Only use blur in the info dialog"
-msgstr ""
+msgstr "Only use blur in the info dialog"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31155"
 msgid "Disable the bounce in animation when scrolling between items."
-msgstr ""
+msgstr "Disable the bounce in animation when scrolling between items."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31156"
 msgid "Apply a colour changing overlay effect to music visualisation background."
-msgstr ""
+msgstr "Apply a colour changing overlay effect to music visualisation background."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31157"
 msgid "A scrolling text effect showing artist, album and song info overlaid on the music visualisation background."
-msgstr ""
+msgstr "A scrolling text effect showing artist, album and song info overlaid on the music visualisation background."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31158"
 msgid "Automatically open visualisation after starting a song"
-msgstr ""
+msgstr "Automatically open visualisation after starting a song"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31159"
 msgid "Video Sources"
-msgstr ""
+msgstr "Video Sources"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31160"
 msgid "Music sources"
-msgstr ""
+msgstr "Music sources"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31161"
 msgid "Showcase"
-msgstr ""
+msgstr "Showcase"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31162"
 msgid "Categories"
-msgstr ""
+msgstr "Categories"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31163"
 msgid "Submenu Items"
-msgstr ""
+msgstr "Submenu Items"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31164"
 msgid "Info List"
-msgstr ""
+msgstr "Info List"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31165"
 msgid "TV recordings"
-msgstr ""
+msgstr "TV recordings"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31166"
 msgid "TV timers"
-msgstr ""
+msgstr "TV timers"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31167"
 msgid "Square list"
-msgstr ""
+msgstr "Square list"
 
 msgctxt "#31168"
 msgid "Startup video or music playlist"
-msgstr ""
+msgstr "Startup video or music playlist"
 
 msgctxt "#31169"
 msgid "Extras"
-msgstr ""
+msgstr "Extras"
 
 msgctxt "#31170"
 msgid "Cinema Experience"
-msgstr ""
+msgstr "Cinema Experience"
 
 msgctxt "#31171"
 msgid "Video Extras"
-msgstr ""
+msgstr "Video Extras"
 
 msgctxt "#31172"
 msgid "Display music visualisation in the background"
-msgstr ""
+msgstr "Display music visualisation in the background"
 
 msgctxt "#31173"
 msgid "Recently added"
-msgstr ""
+msgstr "Recently added"
 
 msgctxt "#31174"
 msgid "Recently played"
-msgstr ""
+msgstr "Recently played"
 
 msgctxt "#31175"
 msgid "Play random"
-msgstr ""
+msgstr "Play random"
 
 msgctxt "#31176"
 msgid "Delete Settings Shortcut"
-msgstr ""
+msgstr "Delete Settings Shortcut"
 
 msgctxt "#31177"
 msgid "Are you sure you want to remove the settings shortcut?[CR]Please ensure that you have an alternative method of accessing settings before you remove this shortcut."
-msgstr ""
+msgstr "Are you sure you want to remove the settings shortcut?[CR]Please ensure that you have an alternative method of accessing settings before you remove this shortcut."
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31178"
 msgid "Show extended info"
-msgstr ""
+msgstr "Show extended info"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31179"
 msgid "Lock view"
-msgstr ""
+msgstr "Lock view"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31180"
 msgid "Unlock view"
-msgstr ""
+msgstr "Unlock view"
 
 msgctxt "#31181"
 msgid "Select icon"
-msgstr ""
+msgstr "Select icon"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31182"
 msgid "Additional Widgets"
-msgstr ""
+msgstr "Additional Widgets"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31183"
 msgid "Default Widgets"
-msgstr ""
+msgstr "Default Widgets"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31184"
 msgid "Recently played movies"
-msgstr ""
+msgstr "Recently played movies"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31185"
 msgid "Recently Added Movies"
-msgstr ""
+msgstr "Recently Added Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31186"
 msgid "Display OSD submenu"
-msgstr ""
+msgstr "Display OSD submenu"
 
 msgctxt "#31187"
 msgid "Random Albums"
-msgstr ""
+msgstr "Random Albums"
 
 msgctxt "#31188"
 msgid "Recent Albums"
-msgstr ""
+msgstr "Recent Albums"
 
 msgctxt "#31189"
 msgid "Recommended Albums"
-msgstr ""
+msgstr "Recommended Albums"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31190"
 msgid "Recently Played Movies"
-msgstr ""
+msgstr "Recently Played Movies"
 
 msgctxt "#31191"
 msgid "Directed by"
-msgstr ""
+msgstr "Directed by"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31192"
 msgid "Focus bounce animation"
-msgstr ""
+msgstr "Focus bounce animation"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31193"
 msgid "Reset colours to default"
-msgstr ""
+msgstr "Reset colours to default"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31194"
 msgid "Recently Played TV Shows"
-msgstr ""
+msgstr "Recently Played TV Shows"
 
 msgctxt "#31195"
 msgid "Reload Skin"
-msgstr ""
+msgstr "Reload Skin"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31196"
 msgid "In Progress TV Shows"
-msgstr ""
+msgstr "In Progress TV Shows"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31197"
 msgid "Save Changes"
-msgstr ""
+msgstr "Save Changes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31198"
 msgid "Recently Played Episodes"
-msgstr ""
+msgstr "Recently Played Episodes"
 
 msgctxt "#31199"
 msgid "Kiosk mode"
-msgstr ""
+msgstr "Kiosk mode"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31200"
 msgid "Random Movies"
-msgstr ""
+msgstr "Random Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31201"
 msgid "Pressing info only displays seekbar (hides poster and plot)"
-msgstr ""
+msgstr "Pressing info only displays seekbar (hides poster and plot)"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31202"
 msgid "Random Episodes"
-msgstr ""
+msgstr "Random Episodes"
 
 msgctxt "#31203"
 msgid "Artwork"
-msgstr ""
+msgstr "Artwork"
 
 msgctxt "#31204"
 msgid "Similar to"
-msgstr ""
+msgstr "Similar to"
 
 msgctxt "#31205"
 msgid "Released by"
-msgstr ""
+msgstr "Released by"
 
 msgctxt "#31206"
 msgid "Similar"
-msgstr ""
+msgstr "Similar"
 
 msgctxt "#31207"
 msgid "themoviedb.org"
-msgstr ""
+msgstr "themoviedb.org"
 
 msgctxt "#31208"
 msgid "In Cinemas"
-msgstr ""
+msgstr "In Cinemas"
 
 msgctxt "#31209"
 msgid "Upcoming"
-msgstr ""
+msgstr "Upcoming"
 
 msgctxt "#31210"
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgctxt "#31211"
 msgid "Top-Rated"
-msgstr ""
+msgstr "Top-Rated"
 
 msgctxt "#31212"
 msgid "Airing"
-msgstr ""
+msgstr "Airing"
 
 msgctxt "#31213"
 msgid "Today"
-msgstr ""
+msgstr "Today"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31214"
 msgid "Recently Added Episodes"
-msgstr ""
+msgstr "Recently Added Episodes"
 
 msgctxt "#31215"
 msgid "Unwatched"
-msgstr ""
+msgstr "Unwatched"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31216"
 msgid "In Progress Movies"
-msgstr ""
+msgstr "In Progress Movies"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31217"
 msgid "Change location"
-msgstr ""
+msgstr "Change location"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31218"
 msgid "In Progress Episodes"
-msgstr ""
+msgstr "In Progress Episodes"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31219"
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
 msgctxt "#31220"
 msgid "Next Aired"
-msgstr ""
+msgstr "Next Aired"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31221"
 msgid "Next Up"
-msgstr ""
+msgstr "Next Up"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31222"
 msgid "Top-Rated TV Shows"
-msgstr ""
+msgstr "Top-Rated TV Shows"
 
 msgctxt "#31223"
 msgid "Upcoming Movies"
-msgstr ""
+msgstr "Upcoming Movies"
 
 msgctxt "#31224"
 msgid "Popular Movies"
-msgstr ""
+msgstr "Popular Movies"
 
 msgctxt "#31225"
 msgid "Top-Rated Movies"
-msgstr ""
+msgstr "Top-Rated Movies"
 
 msgctxt "#31226"
 msgid "Popular TV Shows"
-msgstr ""
+msgstr "Popular TV Shows"
 
 msgctxt "#31227"
 msgid "Top-Rated TV Shows"
-msgstr ""
+msgstr "Top-Rated TV Shows"
 
 msgctxt "#31228"
 msgid "On-Air TV Shows"
-msgstr ""
+msgstr "On-Air TV Shows"
 
 msgctxt "#31229"
 msgid "TV Shows Airing Today"
-msgstr ""
+msgstr "TV Shows Airing Today"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31230"
 msgid "Top-Rated Episodes"
-msgstr ""
+msgstr "Top-Rated Episodes"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31231"
 msgid "Lovefilm"
-msgstr ""
+msgstr "Lovefilm"
 
 msgctxt "#31232"
 msgid "Reset path"
-msgstr ""
+msgstr "Reset path"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31233"
 msgid "Random TV Shows"
-msgstr ""
+msgstr "Random TV Shows"
 
 #: /1080i/SettingsProfile.xml
 msgctxt "#31234"
 msgid "Customise your user profiles and enable/disable the login screen."
-msgstr ""
+msgstr "Customise your user profiles and enable/disable the login screen."
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31235"
 msgid "Set sorting (default$COMMA year$COMMA rating$COMMA lastplayed$COMMA dateadded$COMMA etc.)"
-msgstr ""
+msgstr "Set sorting (default$COMMA year$COMMA rating$COMMA lastplayed$COMMA dateadded$COMMA etc.)"
 
 msgctxt "#31236"
 msgid "Now playing..."
-msgstr ""
+msgstr "Now playing..."
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31237"
 msgid "Sort"
-msgstr ""
+msgstr "Sort"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31238"
 msgid "Recently Added Albums"
-msgstr ""
+msgstr "Recently Added Albums"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31239"
 msgid "Direction"
-msgstr ""
+msgstr "Direction"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31240"
 msgid "Aspect"
-msgstr ""
+msgstr "Aspect"
 
 msgctxt "#31241"
 msgid "Additional info"
-msgstr ""
+msgstr "Additional info"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31242"
 msgid "Recently Played Albums"
-msgstr ""
+msgstr "Recently Played Albums"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31243"
 msgid "Top 100 Albums"
-msgstr ""
+msgstr "Top 100 Albums"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31244"
 msgid "Select Widget"
-msgstr ""
+msgstr "Select Widget"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31245"
 msgid "Customise"
-msgstr ""
+msgstr "Customise"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31246"
 msgid "Press right to customise widgets"
-msgstr ""
+msgstr "Press right to customise widgets"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31247"
 msgid "Widgets"
-msgstr ""
+msgstr "Widgets"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31248"
 msgid "Edit Shortcuts"
-msgstr ""
+msgstr "Edit Shortcuts"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31249"
 msgid "Press right to customise shortcuts"
-msgstr ""
+msgstr "Press right to customise shortcuts"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31250"
 msgid "Gradient colour"
-msgstr ""
+msgstr "Gradient colour"
 
 msgctxt "#31251"
 msgid "Weather Fanart"
-msgstr ""
+msgstr "Weather Fanart"
 
 msgctxt "#31252"
 msgid "Weather Forecast"
-msgstr ""
+msgstr "Weather Forecast"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31253"
 msgid "Use a larger font for the progress bar"
-msgstr ""
+msgstr "Use a larger font for the progress bar"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31254"
 msgid "If you are having difficulties with widgets or home menu items not displaying correctly please make sure that you press the \"save changes\" button to ensure that your shortcuts and widgets are set."
-msgstr ""
+msgstr "If you are having difficulties with widgets or home menu items not displaying correctly please make sure that you press the \"save changes\" button to ensure that your shortcuts and widgets are set."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31255"
 msgid "Generate landscape art"
-msgstr ""
+msgstr "Generate landscape art"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31256"
 msgid "Display artwork"
-msgstr ""
+msgstr "Display artwork"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31257"
 msgid "Movie Genres"
-msgstr ""
+msgstr "Movie Genres"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31258"
 msgid "Clearart with seekbar"
-msgstr ""
+msgstr "Clearart with seekbar"
 
 msgctxt "#31259"
 msgid "Extra fanart"
-msgstr ""
+msgstr "Extra fanart"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31260"
 msgid "Movie Sets"
-msgstr ""
+msgstr "Movie Sets"
 
 msgctxt "#31261"
 msgid "Widget aspect"
-msgstr ""
+msgstr "Widget aspect"
 
 msgctxt "#31262"
 msgid "Poster"
-msgstr ""
+msgstr "Poster"
 
 msgctxt "#31263"
 msgid "Square"
-msgstr ""
+msgstr "Square"
 
 msgctxt "#31264"
 msgid "Thumbnail"
-msgstr ""
+msgstr "Thumbnail"
 
 msgctxt "#31265"
 msgid "Fanart"
-msgstr ""
+msgstr "Fanart"
 
 msgctxt "#31266"
 msgid "Widget"
-msgstr ""
+msgstr "Widget"
 
 msgctxt "#31267"
 msgid "Action"
-msgstr ""
+msgstr "Action"
 
 msgctxt "#31268"
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 msgctxt "#31269"
 msgid "Fallback widget"
-msgstr ""
+msgstr "Fallback widget"
 
 msgctxt "#31270"
 msgid "Video / Music OSD"
-msgstr ""
+msgstr "Video / Music OSD"
 
 msgctxt "#31271"
 msgid "Single Image"
-msgstr ""
+msgstr "Single Image"
 
 msgctxt "#31272"
 msgid "Multi Image"
-msgstr ""
+msgstr "Multi Image"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31273"
 msgid "Background overlay colour"
-msgstr ""
+msgstr "Background overlay colour"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31274"
 msgid "TvShow Genres"
-msgstr ""
+msgstr "TvShow Genres"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31275"
 msgid "Blur fanart"
-msgstr ""
+msgstr "Blur fanart"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31276"
 msgid "IMDB Top 250 Movies"
-msgstr ""
+msgstr "IMDB Top 250 Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31277"
 msgid "Animations"
-msgstr ""
+msgstr "Animations"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31278"
 msgid "Unwatched Movies"
-msgstr ""
+msgstr "Unwatched Movies"
 
 msgctxt "#31279"
 msgid "Video decoder"
-msgstr ""
+msgstr "Video decoder"
 
 msgctxt "#31280"
 msgid "Pixel format"
-msgstr ""
+msgstr "Pixel format"
 
 msgctxt "#31281"
 msgid "by"
-msgstr ""
+msgstr "by"
 
 msgctxt "#31282"
 msgid "on"
-msgstr ""
+msgstr "on"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31283"
 msgid "Unwatched Episodes"
-msgstr ""
+msgstr "Unwatched Episodes"
 
 #: MPAA Rating
 msgctxt "#31284"
 msgid "Classification"
-msgstr ""
+msgstr "Classification"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31285"
 msgid "Extended info"
-msgstr ""
+msgstr "Extended info"
 
 msgctxt "#31286"
 msgid "Highlight colour"
-msgstr ""
+msgstr "Highlight colour"
 
 msgctxt "#31287"
 msgid "Reset to default"
-msgstr ""
+msgstr "Reset to default"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31288"
 msgid "Match highlight colours with the poster"
-msgstr ""
+msgstr "Match highlight colours with the poster"
 
 msgctxt "#31289"
 msgid "Awards"
-msgstr ""
+msgstr "Awards"
 
 msgctxt "#31290"
 msgid "Consensus"
-msgstr ""
+msgstr "Consensus"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31291"
 msgid "Landscape widget text"
-msgstr ""
+msgstr "Landscape widget text"
 
 #: /1080i/DialogBusy.xml
 msgctxt "#31292"
 msgid "Kodi is busy$COMMA one moment, please"
-msgstr ""
+msgstr "Kodi is busy$COMMA one moment, please"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31293"
 msgid "Skin Helper Widgets"
-msgstr ""
+msgstr "Skin Helper Widgets"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31294"
 msgid "PVR / Live TV"
-msgstr ""
+msgstr "PVR / Live TV"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31295"
 msgid "Random Artists"
-msgstr ""
+msgstr "Random Artists"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31296"
 msgid "Movie Nodes"
-msgstr ""
+msgstr "Movie Nodes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31297"
 msgid "TvShow Nodes"
-msgstr ""
+msgstr "TvShow Nodes"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31298"
 msgid "Media Info"
-msgstr ""
+msgstr "Media Info"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31299"
 msgid "Premiered"
-msgstr ""
+msgstr "Premiered"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31300"
 msgid "Music Nodes"
-msgstr ""
+msgstr "Music Nodes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31301"
 msgid "TV Shows"
-msgstr ""
+msgstr "TV Shows"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31302"
 msgid "Music Sources"
-msgstr ""
+msgstr "Music Sources"
 
 #: /1080i/DialogAddonInfo.xml
 msgctxt "#31303"
 msgid "Latest Changes"
-msgstr ""
+msgstr "Latest Changes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31304"
 msgid "Picture Sources"
-msgstr ""
+msgstr "Picture Sources"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31305"
 msgid "Colour cycling"
-msgstr ""
+msgstr "Colour cycling"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31306"
 msgid "Special Features"
-msgstr ""
+msgstr "Special Features"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31307"
 msgid "Prefer plot outline"
-msgstr ""
+msgstr "Prefer plot outline"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31308"
 msgid "Player"
-msgstr ""
+msgstr "Player"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31309"
 msgid "Blur effect type"
-msgstr ""
+msgstr "Blur effect type"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31310"
 msgid "User rating"
-msgstr ""
+msgstr "User rating"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31311"
 msgid "Rate Song"
-msgstr ""
+msgstr "Rate Song"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31312"
 msgid "Enable / disable ratings"
-msgstr ""
+msgstr "Enable / disable ratings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31313"
 msgid "Background transparency"
-msgstr ""
+msgstr "Background transparency"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31314"
 msgid "Automatically display music video info at the beginning and end of a clip"
-msgstr ""
+msgstr "Automatically display music video info at the beginning and end of a clip"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31315"
 msgid "CinemaVision"
-msgstr ""
+msgstr "CinemaVision"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31316"
 msgid "Increased"
-msgstr ""
+msgstr "Increased"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31317"
 msgid "Watched indicators"
-msgstr ""
+msgstr "Watched indicators"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31318"
 msgid "Shadows"
-msgstr ""
+msgstr "Shadows"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31319"
 msgid "Indicator style"
-msgstr ""
+msgstr "Indicator style"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31320"
 msgid "Important"
-msgstr ""
+msgstr "Important"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31321"
 msgid "Reset to defaults"
-msgstr ""
+msgstr "Reset to defaults"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31322"
 msgid "Image quality changes the resolution of the generated image. Better quality images take longer to process. Quality changes can alter the intensity of the effect in addition to other effect settings. The blend setting will blend the effect with the original image$COMMA with a value of 100 showing the full image effect."
-msgstr ""
+msgstr "Image quality changes the resolution of the generated image. Better quality images take longer to process. Quality changes can alter the intensity of the effect in addition to other effect settings. The blend setting will blend the effect with the original image$COMMA with a value of 100 showing the full image effect."
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31323"
 msgid "Blend"
-msgstr ""
+msgstr "Blend"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31324"
 msgid "Bitsize"
-msgstr ""
+msgstr "Bitsize"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31325"
 msgid "Pixel size"
-msgstr ""
+msgstr "Pixel size"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31326"
 msgid "Blur radius"
-msgstr ""
+msgstr "Blur radius"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31327"
 msgid "Image quality"
-msgstr ""
+msgstr "Image quality"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31328"
 msgid "Highest"
-msgstr ""
+msgstr "Highest"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31329"
 msgid "Colorbox Advanced Settings"
-msgstr ""
+msgstr "Colorbox Advanced Settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31330"
 msgid "Advanced settings for colorbox (blur settings)"
-msgstr ""
+msgstr "Advanced settings for colorbox (blur settings)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31331"
 msgid "Icon only mode"
-msgstr ""
+msgstr "Icon only mode"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31332"
 msgid "Change image"
-msgstr ""
+msgstr "Change image"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31333"
 msgid "Programmes"
-msgstr ""
+msgstr "Programmes"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31334"
 msgid "Alphabet strip is not available for this content"
-msgstr ""
+msgstr "Alphabet strip is not available for this content"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31335"
 msgid "Match background overlay colour with the poster"
-msgstr ""
+msgstr "Match background overlay colour with the poster"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31336"
 msgid "Background overlay"
-msgstr ""
+msgstr "Background overlay"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31337"
 msgid "Light"
-msgstr ""
+msgstr "Light"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31338"
 msgid "Background vignette"
-msgstr ""
+msgstr "Background vignette"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31339"
 msgid "Effects"
-msgstr ""
+msgstr "Effects"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31340"
 msgid "Match poster"
-msgstr ""
+msgstr "Match poster"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31341"
 msgid "Dark"
-msgstr ""
+msgstr "Dark"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31342"
 msgid "Widget item limit"
-msgstr ""
+msgstr "Widget item limit"
 
 #: /1080i/Settings.xml
 msgctxt "#31343"
 msgid "PVR"
-msgstr ""
+msgstr "PVR"
 
 #: /1080i/Settings.xml
 msgctxt "#31344"
 msgid "Install from repository or zip"
-msgstr ""
+msgstr "Install from repository or zip"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31345"
 msgid "Event logging"
-msgstr ""
+msgstr "Event logging"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31346"
 msgid "Video OSD"
-msgstr ""
+msgstr "Video OSD"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31347"
 msgid "Music OSD"
-msgstr ""
+msgstr "Music OSD"
 
 #: /1080i/Home.xml
 msgctxt "#31348"
 msgid "Loading Home Menu"
-msgstr ""
+msgstr "Loading Home Menu"
 
 #: /1080i/Startup.xml
 msgctxt "#31349"
 msgid "Initialising Skin"
-msgstr ""
+msgstr "Initialising Skin"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31350"
 msgid "Similar to "
-msgstr ""
+msgstr "Similar to "
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31351"
 msgid "Directed by "
-msgstr ""
+msgstr "Directed by "
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31352"
 msgid "Added"
-msgstr ""
+msgstr "Added"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31353"
 msgid "Played"
-msgstr ""
+msgstr "Played"
 
 #: /1080i/DialogMusicInfo.xml
 msgctxt "#31354"
 msgid "Instrument"
-msgstr ""
+msgstr "Instrument"
 
 #: /1080i/DialogMusicInfo.xml
 msgctxt "#31355"
 msgid "Mood"
-msgstr ""
+msgstr "Mood"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31356"
 msgid "Years Old"
-msgstr ""
+msgstr "Years Old"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31357"
 msgid "Crew"
-msgstr ""
+msgstr "Crew"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31358"
 msgid "Poster Wall"
-msgstr ""
+msgstr "Poster Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31359"
 msgid "Landscape Wall"
-msgstr ""
+msgstr "Landscape Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31360"
 msgid "Square Wall"
-msgstr ""
+msgstr "Square Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31361"
 msgid "Landscape Showcase"
-msgstr ""
+msgstr "Landscape Showcase"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31362"
 msgid "Square Showcase"
-msgstr ""
+msgstr "Square Showcase"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31363"
 msgid "Big Posters"
-msgstr ""
+msgstr "Big Posters"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31364"
 msgid "Mouse compatibility"
-msgstr ""
+msgstr "Mouse compatibility"
 
 #: /1080i/script-script.extendedinfo-DialogVideoInfo.xml
 msgctxt "#31365"
 msgid "Images"
-msgstr ""
+msgstr "Images"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31366"
 msgid "Artwork button downloads all artwork"
-msgstr ""
+msgstr "Artwork button downloads all artwork"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31367"
 msgid "Recently Added TV Shows"
-msgstr ""
+msgstr "Recently Added TV Shows"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31368"
 msgid "Tagged Images"
-msgstr ""
+msgstr "Tagged Images"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31369"
 msgid "Prefer fanart for landscape widgets"
-msgstr ""
+msgstr "Prefer fanart for landscape widgets"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31370"
 msgid "Banner Wall"
-msgstr ""
+msgstr "Banner Wall"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31371"
 msgid "Categories widget text"
-msgstr ""
+msgstr "Categories widget text"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31372"
 msgid "Force default menu position"
-msgstr ""
+msgstr "Force default menu position"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31373"
 msgid "See More"
-msgstr ""
+msgstr "See More"
 
 #: /1080i/EventLog.xml
 msgctxt "#31374"
 msgid "Order"
-msgstr ""
+msgstr "Order"
 
 #: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
 msgctxt "#31375"
 msgid "Gradients on backing panels"
-msgstr ""
+msgstr "Gradients on backing panels"
 
 #: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
 msgctxt "#31376"
 msgid "Show the \"See More\" widget item"
-msgstr ""
+msgstr "Show the \"See More\" widget item"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31377"
 msgid "Video lyrics"
-msgstr ""
+msgstr "Video lyrics"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31378"
 msgid "Genre names in PVR guide"
-msgstr ""
+msgstr "Genre names in PVR guide"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31379"
 msgid "Display plot overlay after a delay"
-msgstr ""
+msgstr "Display plot overlay after a delay"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31380"
 msgid "Untitled"
-msgstr ""
+msgstr "Untitled"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31381"
 msgid "Last Played Channels"
-msgstr ""
+msgstr "Last Played Channels"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31382"
 msgid "Active Recordings"
-msgstr ""
+msgstr "Active Recordings"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31383"
 msgid "Grouped Active Recordings"
-msgstr ""
+msgstr "Grouped Active Recordings"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31384"
 msgid "Grouped Deleted Recordings"
-msgstr ""
+msgstr "Grouped Deleted Recordings"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31385"
 msgid "Episode List"
-msgstr ""
+msgstr "Episode List"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31386"
 msgid "Auto close OSD controls after a delay (in seconds)"
-msgstr ""
+msgstr "Auto close OSD controls after a delay (in seconds)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31387"
 msgid "Splash screen image"
-msgstr ""
+msgstr "Splash screen image"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31388"
 msgid "Download All Artwork"
-msgstr ""
+msgstr "Download All Artwork"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31389"
 msgid "Select Artwork"
-msgstr ""
+msgstr "Select Artwork"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31390"
 msgid "Pressing up from top menu shows fanart / plot"
-msgstr ""
+msgstr "Pressing up from top menu shows fanart / plot"
 
 #: /1080i/Includes_Topbar.xml
 msgctxt "#31391"
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31392"
 msgid "Sort Letter"
-msgstr ""
+msgstr "Sort Letter"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31393"
 msgid "Show media flags instead of ratings in library views"
-msgstr ""
+msgstr "Show media flags instead of ratings in library views"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31394"
 msgid "Monochrome flags"
-msgstr ""
+msgstr "Monochrome flags"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31395"
 msgid "Music Playlist"
-msgstr ""
+msgstr "Music Playlist"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31396"
 msgid "Video Playlist"
-msgstr ""
+msgstr "Video Playlist"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31397"
 msgid "Square Wall Large"
-msgstr ""
+msgstr "Square Wall Large"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31398"
 msgid "Force extendedinfo to open when pressing info"
-msgstr ""
+msgstr "Force extendedinfo to open when pressing info"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31399"
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31400"
 msgid "Movies by Director"
-msgstr ""
+msgstr "Movies by Director"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31401"
 msgid "Next Up Episodes"
-msgstr ""
+msgstr "Next Up Episodes"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31402"
 msgid "Similar Movies"
-msgstr ""
+msgstr "Similar Movies"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31403"
 msgid "Similar Tv Shows"
-msgstr ""
+msgstr "Similar Tv Shows"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31404"
 msgid "Movies from Studio"
-msgstr ""
+msgstr "Movies from Studio"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31405"
 msgid "Extrafanart"
-msgstr ""
+msgstr "Extrafanart"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31406"
 msgid "Extras / Special Features"
-msgstr ""
+msgstr "Extras / Special Features"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31407"
 msgid "Enable / disable info dialog lists"
-msgstr ""
+msgstr "Enable / disable info dialog lists"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31408"
 msgid "Subtitle settings"
-msgstr ""
+msgstr "Subtitle settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31409"
 msgid "Subtitles button opens subtitle settings"
-msgstr ""
+msgstr "Subtitles button opens subtitle settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31410"
 msgid "Show trailers and special features in the preview window"
-msgstr ""
+msgstr "Show trailers and special features in the preview window"
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31411"
 msgid "Unavailable"
-msgstr ""
+msgstr "Unavailable"

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -7,7 +7,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
+"Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: /1080i/Includes_Global.xml

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -1,0 +1,1965 @@
+# Kodi Media Center language file
+# Addon Name: Horizon
+# Addon id: skin.horizon
+# Addon Provider: jurialmunkey
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: /1080i/Includes_Global.xml
+msgctxt "#31000"
+msgid "Reduced"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31001"
+msgid "Revenue"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31002"
+msgid "Categories widget"
+msgstr ""
+
+#: /1080i/Includes_Furniture.xml
+msgctxt "#31003"
+msgid "Current conditions"
+msgstr ""
+
+#: /1080i/Includes_Furniture.xml
+msgctxt "#31004"
+msgid "Sunset at"
+msgstr ""
+
+#: /1080i/Includes_Furniture.xml
+msgctxt "#31005"
+msgid "Sunrise at"
+msgstr ""
+
+#: /1080i/Includes_Furniture.xml
+msgctxt "#31006"
+msgid "Weather provided by"
+msgstr ""
+
+#: /1080i/Includes_Furniture.xml
+msgctxt "#31007"
+msgid "Weather forecast for"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31008"
+msgid "Install weather fanart"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31009"
+msgid "Complete"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31010"
+msgid "Weather fanart successfully installed"
+msgstr ""
+
+#: /1080i/MyWeather.xml
+msgctxt "#31011"
+msgid "Default weather icons"
+msgstr ""
+
+#: /1080i/MyWeather.xml
+msgctxt "#31012"
+msgid "Weather fanart installed"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31013"
+msgid "Set weather icons"
+msgstr ""
+
+#: /1080i/MyVideoNav.xml
+msgctxt "#31014"
+msgid "Extra fanart"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31015"
+msgid "Minimal busy loader"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31016"
+msgid "By"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31017"
+msgid "Smart Shortcuts"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31018"
+msgid "Common Shortcut"
+msgstr ""
+
+#: /1080i/script-globalsearch-main.xml
+msgctxt "#31019"
+msgid "Close"
+msgstr ""
+
+#: /1080i/script-globalsearch-main.xml
+msgctxt "#31020"
+msgid "mins"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31021"
+msgid "Colors"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31022"
+msgid "Animated artwork"
+msgstr ""
+
+#: /1080i/Includes_Statusbar.xml
+msgctxt "#31023"
+msgid "Fullscreen"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31024"
+msgid "Miscellaneous"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31025"
+msgid "From"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31026"
+msgid "Alphabet strip"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31027"
+msgid "Customize power menu"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31028"
+msgid "Reset skin settings to defaults (WARNING: This will reset your home menu to skin defaults)"
+msgstr ""
+
+#: /1080i/script-nextup-notification-PostPlayInfo.xml
+msgctxt "#31029"
+msgid "Hide Spoilers"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31030"
+msgid "Backup / Restore"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31031"
+msgid "Backup skin settings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31032"
+msgid "Restore skin settings"
+msgstr ""
+
+#: /1080i/Includes_Items.xml
+msgctxt "#31033"
+msgid "Audio Settings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31034"
+msgid "Change backup and restore path"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31035"
+msgid "hrs"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31036"
+msgid "hr"
+msgstr ""
+
+#: /1080i/DialogSubtitles.xml
+msgctxt "#31037"
+msgid "Download Subtitles"
+msgstr ""
+
+#: /1080i/Includes_View.xml
+msgctxt "#31038"
+msgid "Landscape"
+msgstr ""
+
+#: /1080i/Custom_1117_EnableViews.xml
+msgctxt "#31039"
+msgid "Enable / disable view modes"
+msgstr ""
+
+#: /1080i/Custom_1117_EnableViews.xml
+msgctxt "#31040"
+msgid "Poster Showcase"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31041"
+msgid "Customize your home menu items, widgets, and backgrounds."
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31042"
+msgid "Wall view text labels"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31043"
+msgid "Select Action"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31044"
+msgid "Search library for movies staring"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31045"
+msgid "Show extended info about"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31046"
+msgid "Search library"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31047"
+msgid "This disables fanart in the library and shows the fallback image instead."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31048"
+msgid "Set a fallback image for when no fanart is available."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31049"
+msgid "Display artist fanart stored from the library database on the music visualization screen."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31050"
+msgid "Use artist slideshow addon to display artist fanart on the music visualization screen."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31051"
+msgid "Make the artist fanart slightly transparent so that the music visualization shows through."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31052"
+msgid "Use a pan and zoom effect on the artist fanart in the music visualization."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31053"
+msgid "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31054"
+msgid "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31055"
+msgid "Use skinhelper to provide animated posters and fanart. These can be downloaded from the context menu."
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31056"
+msgid "Genre colors in PVR guide"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31057"
+msgid "Use fullscreen PVR guide (hide plot info)"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31058"
+msgid "Change the highlight focus color used throughout the skin."
+msgstr ""
+
+#: /1080i/DialogContextMenu.xml
+msgctxt "#31059"
+msgid "Context Menu"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31060"
+msgid "Set music or video playlist that will run when Kodi starts."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31061"
+msgid "Disable the alphabet strip and always use scrollbars instead."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31062"
+msgid "Disable changing view settings and some settings buttons in information dialogs."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31063"
+msgid "Change the items displayed in the power menu."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31064"
+msgid "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31065"
+msgid "Restore your skin settings, shortcuts, and widgets from a backup file."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31066"
+msgid "Change the location where skin backup files are saved."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31067"
+msgid "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
+msgstr ""
+
+#: /1080i/Includes_Weather.xml
+msgctxt "#31068"
+msgid "Cloud cover"
+msgstr ""
+
+#: /1080i/Includes_Weather.xml
+msgctxt "#31069"
+msgid "Cloud cover is "
+msgstr ""
+
+#: /1080i/Includes_Weather.xml
+msgctxt "#31070"
+msgid "Cloud Cover"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31071"
+msgid "IMDB Top250"
+msgstr ""
+
+#: /1080i/DialogButtonMenu.xml
+msgctxt "#31072"
+msgid "Power Menu"
+msgstr ""
+
+#: /1080i/VideoOSD.xml
+msgctxt "#31073"
+msgid "Recommended Youtube Videos"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31074"
+msgid "Make bottombar transparent"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31075"
+msgid "Apply transparency to bottombar"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31076"
+msgid "Enable transparency"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31077"
+msgid "Add slight transparency to the top and bottombars."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31078"
+msgid "Ended"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31079"
+msgid "Pause video when opening extended info"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31080"
+msgid "Artwork button downloads all available artwork (as specified in artwork downloader settings)"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31081"
+msgid "Hide plot"
+msgstr ""
+
+#: /1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31082"
+msgid "Video process information"
+msgstr ""
+
+#: /1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31083"
+msgid "Framerate"
+msgstr ""
+
+#: /1080i/DialogPlayerProcessInfo.xml
+msgctxt "#31084"
+msgid "Aspect Ratio"
+msgstr ""
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31085"
+msgid "Codec Info"
+msgstr ""
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31086"
+msgid "Extended Info"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31087"
+msgid "Color overlay effect"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31088"
+msgid "Scrolling text effect"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31089"
+msgid "Position context menu based on the focused item"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31090"
+msgid "Display duration format as X HRS XX MINS"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31091"
+msgid "Prefer list view for seasons"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31092"
+msgid "System Name"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31093"
+msgid "Gateway Address"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31094"
+msgid "Network and Storage"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31095"
+msgid "Video Encoder"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31096"
+msgid "Memory"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31097"
+msgid "Fan Speed"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31098"
+msgid "CPU Info"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31099"
+msgid "CPU Usage"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31100"
+msgid "Processor, Memory, and Video"
+msgstr ""
+
+msgctxt "#31101"
+msgid "items"
+msgstr ""
+
+msgctxt "#31102"
+msgid "min"
+msgstr ""
+
+msgctxt "#31103"
+msgid "Live TV"
+msgstr ""
+
+msgctxt "#31104"
+msgid "Used Memory"
+msgstr ""
+
+msgctxt "#31105"
+msgid "Spotlight"
+msgstr ""
+
+msgctxt "#31106"
+msgid "Ends "
+msgstr ""
+
+msgctxt "#31107"
+msgid "Video Stream"
+msgstr ""
+
+msgctxt "#31108"
+msgid "Current Menu"
+msgstr ""
+
+msgctxt "#31109"
+msgid "Customize home menu"
+msgstr ""
+
+msgctxt "#31110"
+msgid "Background"
+msgstr ""
+
+msgctxt "#31111"
+msgid "Display now playing video in the background"
+msgstr ""
+
+msgctxt "#31112"
+msgid "Submenu"
+msgstr ""
+
+msgctxt "#31113"
+msgid "No Timer"
+msgstr ""
+
+msgctxt "#31114"
+msgid "Now Playing"
+msgstr ""
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31115"
+msgid "Recommended"
+msgstr ""
+
+msgctxt "#31116"
+msgid "DVD Menu"
+msgstr ""
+
+msgctxt "#31117"
+msgid "3D Mode"
+msgstr ""
+
+msgctxt "#31118"
+msgid "Artist slideshow"
+msgstr ""
+
+msgctxt "#31119"
+msgid "Visualization behind slideshow"
+msgstr ""
+
+msgctxt "#31120"
+msgid "Animate artist slideshow"
+msgstr ""
+
+msgctxt "#31121"
+msgid "Fanart"
+msgstr ""
+
+msgctxt "#31122"
+msgid "Ongoing Episodes"
+msgstr ""
+
+msgctxt "#31123"
+msgid "Resumable Movies"
+msgstr ""
+
+msgctxt "#31124"
+msgid "Recent Movies"
+msgstr ""
+
+msgctxt "#31125"
+msgid "Recent Episodes"
+msgstr ""
+
+msgctxt "#31126"
+msgid "Episodes Spotlight"
+msgstr ""
+
+msgctxt "#31127"
+msgid "Movies Spotlight"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31128"
+msgid "Allow scrolling through items when in full fanart mode"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31129"
+msgid "Enable full fanart mode"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31130"
+msgid "Media flags"
+msgstr ""
+
+#: /1080i/MusicOSD.xml
+msgctxt "#31131"
+msgid "Color overlay"
+msgstr ""
+
+msgctxt "#31132"
+msgid "Reset home menu shortcuts to defaults"
+msgstr ""
+
+msgctxt "#31133"
+msgid "Hide watched"
+msgstr ""
+
+msgctxt "#31134"
+msgid "Trending Movies"
+msgstr ""
+
+msgctxt "#31135"
+msgid "Trending Shows"
+msgstr ""
+
+msgctxt "#31136"
+msgid "Airing Shows"
+msgstr ""
+
+msgctxt "#31137"
+msgid "Premiering Shows"
+msgstr ""
+
+msgctxt "#31138"
+msgid "Content Loading"
+msgstr ""
+
+msgctxt "#31139"
+msgid "Box Office"
+msgstr ""
+
+msgctxt "#31140"
+msgid "Budget"
+msgstr ""
+
+msgctxt "#31141"
+msgid "Youtube"
+msgstr ""
+
+#: /1080i/MusicOSD.xml
+msgctxt "#31142"
+msgid "Scrolling text"
+msgstr ""
+
+msgctxt "#31143"
+msgid "Set weather fanart"
+msgstr ""
+
+msgctxt "#31144"
+msgid "Edit Widgets"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31145"
+msgid "Display poster and plot when a video is paused"
+msgstr ""
+
+msgctxt "#31146"
+msgid "Animate fanart"
+msgstr ""
+
+msgctxt "#31147"
+msgid "Extra Info"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31148"
+msgid "Hide artwork"
+msgstr ""
+
+msgctxt "#31149"
+msgid "Replace widget fanart with background"
+msgstr ""
+
+msgctxt "#31150"
+msgid "Set fallback image"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31151"
+msgid "Hide tvshow labels"
+msgstr ""
+
+msgctxt "#31152"
+msgid "Furniture"
+msgstr ""
+
+#: /1080i/Includes_Statusbar.xml
+msgctxt "#31153"
+msgid "Sort by:"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31154"
+msgid "Only use blur in the info dialog"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31155"
+msgid "Disable the bounce in animation when scrolling between items."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31156"
+msgid "Apply a color changing overlay effect to music visualization background."
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31157"
+msgid "A scrolling text effect showing artist, album and song info overlaid on the music visualization background."
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31158"
+msgid "Automatically open visualization after starting a song"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31159"
+msgid "Video Sources"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31160"
+msgid "Music sources"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31161"
+msgid "Showcase"
+msgstr ""
+
+#: /1080i/Includes_Widgets.xml
+msgctxt "#31162"
+msgid "Categories"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31163"
+msgid "Submenu Items"
+msgstr ""
+
+#: /1080i/Includes_View_List.xml
+msgctxt "#31164"
+msgid "Info List"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31165"
+msgid "TV recordings"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31166"
+msgid "TV timers"
+msgstr ""
+
+#: /1080i/Includes_View_List.xml
+msgctxt "#31167"
+msgid "Square list"
+msgstr ""
+
+msgctxt "#31168"
+msgid "Startup video or music playlist"
+msgstr ""
+
+msgctxt "#31169"
+msgid "Extras"
+msgstr ""
+
+msgctxt "#31170"
+msgid "Cinema Experience"
+msgstr ""
+
+msgctxt "#31171"
+msgid "Video Extras"
+msgstr ""
+
+msgctxt "#31172"
+msgid "Display music visualization in the background"
+msgstr ""
+
+msgctxt "#31173"
+msgid "Recently added"
+msgstr ""
+
+msgctxt "#31174"
+msgid "Recently played"
+msgstr ""
+
+msgctxt "#31175"
+msgid "Play random"
+msgstr ""
+
+msgctxt "#31176"
+msgid "Delete Settings Shortcut"
+msgstr ""
+
+msgctxt "#31177"
+msgid "Are you sure you want to remove the settings shortcut?[CR]Please ensure that you have an alternative method of accessing settings before you remove this shortcut."
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31178"
+msgid "Show extended info"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31179"
+msgid "Lock view"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31180"
+msgid "Unlock view"
+msgstr ""
+
+msgctxt "#31181"
+msgid "Select icon"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31182"
+msgid "Additional Widgets"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31183"
+msgid "Default Widgets"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31184"
+msgid "Recently played movies"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31185"
+msgid "Recently Added Movies"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31186"
+msgid "Display OSD submenu"
+msgstr ""
+
+msgctxt "#31187"
+msgid "Random Albums"
+msgstr ""
+
+msgctxt "#31188"
+msgid "Recent Albums"
+msgstr ""
+
+msgctxt "#31189"
+msgid "Recommended Albums"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31190"
+msgid "Recently Played Movies"
+msgstr ""
+
+msgctxt "#31191"
+msgid "Directed by"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31192"
+msgid "Focus bounce animation"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31193"
+msgid "Reset colors to default"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31194"
+msgid "Recently Played TV Shows"
+msgstr ""
+
+msgctxt "#31195"
+msgid "Reload Skin"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31196"
+msgid "In Progress TV Shows"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31197"
+msgid "Save Changes"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31198"
+msgid "Recently Played Episodes"
+msgstr ""
+
+msgctxt "#31199"
+msgid "Kiosk mode"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31200"
+msgid "Random Movies"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31201"
+msgid "Pressing info only displays seekbar (hides poster and plot)"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31202"
+msgid "Random Episodes"
+msgstr ""
+
+msgctxt "#31203"
+msgid "Artwork"
+msgstr ""
+
+msgctxt "#31204"
+msgid "Similar to"
+msgstr ""
+
+msgctxt "#31205"
+msgid "Released by"
+msgstr ""
+
+msgctxt "#31206"
+msgid "Similar"
+msgstr ""
+
+msgctxt "#31207"
+msgid "themoviedb.org"
+msgstr ""
+
+msgctxt "#31208"
+msgid "In Cinemas"
+msgstr ""
+
+msgctxt "#31209"
+msgid "Upcoming"
+msgstr ""
+
+msgctxt "#31210"
+msgid "Popular"
+msgstr ""
+
+msgctxt "#31211"
+msgid "Top-Rated"
+msgstr ""
+
+msgctxt "#31212"
+msgid "Airing"
+msgstr ""
+
+msgctxt "#31213"
+msgid "Today"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31214"
+msgid "Recently Added Episodes"
+msgstr ""
+
+msgctxt "#31215"
+msgid "Unwatched"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31216"
+msgid "In Progress Movies"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31217"
+msgid "Change location"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31218"
+msgid "In Progress Episodes"
+msgstr ""
+
+#: /1080i/script-nextup-notification-PostPlayInfo.xml
+msgctxt "#31219"
+msgid "Previous"
+msgstr ""
+
+msgctxt "#31220"
+msgid "Next Aired"
+msgstr ""
+
+#: /1080i/script-nextup-notification-PostPlayInfo.xml
+msgctxt "#31221"
+msgid "Next Up"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31222"
+msgid "Top-Rated TV Shows"
+msgstr ""
+
+msgctxt "#31223"
+msgid "Upcoming Movies"
+msgstr ""
+
+msgctxt "#31224"
+msgid "Popular Movies"
+msgstr ""
+
+msgctxt "#31225"
+msgid "Top-Rated Movies"
+msgstr ""
+
+msgctxt "#31226"
+msgid "Popular TV Shows"
+msgstr ""
+
+msgctxt "#31227"
+msgid "Top-Rated TV Shows"
+msgstr ""
+
+msgctxt "#31228"
+msgid "On-Air TV Shows"
+msgstr ""
+
+msgctxt "#31229"
+msgid "TV Shows Airing Today"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31230"
+msgid "Top-Rated Episodes"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31231"
+msgid "Lovefilm"
+msgstr ""
+
+msgctxt "#31232"
+msgid "Reset path"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31233"
+msgid "Random TV Shows"
+msgstr ""
+
+#: /1080i/SettingsProfile.xml
+msgctxt "#31234"
+msgid "Customize your user profiles and enable/disable the login screen."
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31235"
+msgid "Set sorting (default$COMMA year$COMMA rating$COMMA lastplayed$COMMA dateadded$COMMA etc.)"
+msgstr ""
+
+msgctxt "#31236"
+msgid "Now playing..."
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31237"
+msgid "Sort"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31238"
+msgid "Recently Added Albums"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31239"
+msgid "Direction"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31240"
+msgid "Aspect"
+msgstr ""
+
+msgctxt "#31241"
+msgid "Additional info"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31242"
+msgid "Recently Played Albums"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31243"
+msgid "Top 100 Albums"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31244"
+msgid "Select Widget"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31245"
+msgid "Customize"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31246"
+msgid "Press right to customize widgets"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31247"
+msgid "Widgets"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31248"
+msgid "Edit Shortcuts"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31249"
+msgid "Press right to customize shortcuts"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31250"
+msgid "Gradient color"
+msgstr ""
+
+msgctxt "#31251"
+msgid "Weather Fanart"
+msgstr ""
+
+msgctxt "#31252"
+msgid "Weather Forecast"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31253"
+msgid "Use a larger font for the progress bar"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31254"
+msgid "If you are having difficulties with widgets or home menu items not displaying correctly please make sure that you press the \"save changes\" button to ensure that your shortcuts and widgets are set."
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31255"
+msgid "Generate landscape art"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31256"
+msgid "Display artwork"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31257"
+msgid "Movie Genres"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31258"
+msgid "Clearart with seekbar"
+msgstr ""
+
+msgctxt "#31259"
+msgid "Extra fanart"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31260"
+msgid "Movie Sets"
+msgstr ""
+
+msgctxt "#31261"
+msgid "Widget aspect"
+msgstr ""
+
+msgctxt "#31262"
+msgid "Poster"
+msgstr ""
+
+msgctxt "#31263"
+msgid "Square"
+msgstr ""
+
+msgctxt "#31264"
+msgid "Thumbnail"
+msgstr ""
+
+msgctxt "#31265"
+msgid "Fanart"
+msgstr ""
+
+msgctxt "#31266"
+msgid "Widget"
+msgstr ""
+
+msgctxt "#31267"
+msgid "Action"
+msgstr ""
+
+msgctxt "#31268"
+msgid "Label"
+msgstr ""
+
+msgctxt "#31269"
+msgid "Fallback widget"
+msgstr ""
+
+msgctxt "#31270"
+msgid "Video / Music OSD"
+msgstr ""
+
+msgctxt "#31271"
+msgid "Single Image"
+msgstr ""
+
+msgctxt "#31272"
+msgid "Multi Image"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31273"
+msgid "Background overlay color"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31274"
+msgid "TvShow Genres"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31275"
+msgid "Blur fanart"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31276"
+msgid "IMDB Top 250 Movies"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31277"
+msgid "Animations"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31278"
+msgid "Unwatched Movies"
+msgstr ""
+
+msgctxt "#31279"
+msgid "Video decoder"
+msgstr ""
+
+msgctxt "#31280"
+msgid "Pixel format"
+msgstr ""
+
+msgctxt "#31281"
+msgid "by"
+msgstr ""
+
+msgctxt "#31282"
+msgid "on"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31283"
+msgid "Unwatched Episodes"
+msgstr ""
+
+#: MPAA Rating
+msgctxt "#31284"
+msgid "Classification"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31285"
+msgid "Extended info"
+msgstr ""
+
+msgctxt "#31286"
+msgid "Highlight color"
+msgstr ""
+
+msgctxt "#31287"
+msgid "Reset to default"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31288"
+msgid "Match highlight colors with the poster"
+msgstr ""
+
+msgctxt "#31289"
+msgid "Awards"
+msgstr ""
+
+msgctxt "#31290"
+msgid "Consensus"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31291"
+msgid "Landscape widget text"
+msgstr ""
+
+#: /1080i/DialogBusy.xml
+msgctxt "#31292"
+msgid "Kodi is busy$COMMA one moment, please"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31293"
+msgid "Skin Helper Widgets"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31294"
+msgid "PVR / Live TV"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31295"
+msgid "Random Artists"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31296"
+msgid "Movie Nodes"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31297"
+msgid "TvShow Nodes"
+msgstr ""
+
+#: /1080i/Includes_View_List.xml
+msgctxt "#31298"
+msgid "Media Info"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31299"
+msgid "Premiered"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31300"
+msgid "Music Nodes"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31301"
+msgid "TV Shows"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31302"
+msgid "Music Sources"
+msgstr ""
+
+#: /1080i/DialogAddonInfo.xml
+msgctxt "#31303"
+msgid "Latest Changes"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31304"
+msgid "Picture Sources"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31305"
+msgid "Color cycling"
+msgstr ""
+
+#: /1080i/Includes_Items.xml
+msgctxt "#31306"
+msgid "Special Features"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31307"
+msgid "Prefer plot outline"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31308"
+msgid "Player"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31309"
+msgid "Blur effect type"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31310"
+msgid "User rating"
+msgstr ""
+
+#: /1080i/Includes_OSD.xml
+msgctxt "#31311"
+msgid "Rate Song"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31312"
+msgid "Enable / disable ratings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31313"
+msgid "Background transparency"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31314"
+msgid "Automatically display music video info at the beginning and end of a clip"
+msgstr ""
+
+#: /1080i/Includes_Home.xml
+msgctxt "#31315"
+msgid "CinemaVision"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31316"
+msgid "Increased"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31317"
+msgid "Watched indicators"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31318"
+msgid "Shadows"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31319"
+msgid "Indicator style"
+msgstr ""
+
+#: /1080i/script-skinshortcuts.xml
+msgctxt "#31320"
+msgid "Important"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31321"
+msgid "Reset to defaults"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31322"
+msgid "Image quality changes the resolution of the generated image. Better quality images take longer to process. Quality changes can alter the intensity of the effect in addition to other effect settings. The blend setting will blend the effect with the original image$COMMA with a value of 100 showing the full image effect."
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31323"
+msgid "Blend"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31324"
+msgid "Bitsize"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31325"
+msgid "Pixel size"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31326"
+msgid "Blur radius"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31327"
+msgid "Image quality"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31328"
+msgid "Highest"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31329"
+msgid "Colorbox Advanced Settings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31330"
+msgid "Advanced settings for colorbox (blur settings)"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31331"
+msgid "Icon only mode"
+msgstr ""
+
+#: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
+msgctxt "#31332"
+msgid "Change image"
+msgstr ""
+
+#: /1080i/script-globalsearch-main.xml
+msgctxt "#31333"
+msgid "Programmes"
+msgstr ""
+
+#: /1080i/Includes_Object.xml
+msgctxt "#31334"
+msgid "Alphabet strip is not available for this content"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31335"
+msgid "Match background overlay color with the poster"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31336"
+msgid "Background overlay"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31337"
+msgid "Light"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31338"
+msgid "Background vignette"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31339"
+msgid "Effects"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31340"
+msgid "Match poster"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31341"
+msgid "Dark"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31342"
+msgid "Widget item limit"
+msgstr ""
+
+#: /1080i/Settings.xml
+msgctxt "#31343"
+msgid "PVR"
+msgstr ""
+
+#: /1080i/Settings.xml
+msgctxt "#31344"
+msgid "Install from repository or zip"
+msgstr ""
+
+#: /1080i/Includes_Widgets.xml
+msgctxt "#31345"
+msgid "Event logging"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31346"
+msgid "Video OSD"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31347"
+msgid "Music OSD"
+msgstr ""
+
+#: /1080i/Home.xml
+msgctxt "#31348"
+msgid "Loading Home Menu"
+msgstr ""
+
+#: /1080i/Startup.xml
+msgctxt "#31349"
+msgid "Initializing Skin"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31350"
+msgid "Similar to "
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31351"
+msgid "Directed by "
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31352"
+msgid "Added"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31353"
+msgid "Played"
+msgstr ""
+
+#: /1080i/DialogMusicInfo.xml
+msgctxt "#31354"
+msgid "Instrument"
+msgstr ""
+
+#: /1080i/DialogMusicInfo.xml
+msgctxt "#31355"
+msgid "Mood"
+msgstr ""
+
+#: /1080i/script-script.extendedinfo-DialogInfo.xml
+msgctxt "#31356"
+msgid "Years Old"
+msgstr ""
+
+#: /1080i/script-script.extendedinfo-DialogInfo.xml
+msgctxt "#31357"
+msgid "Crew"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31358"
+msgid "Poster Wall"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31359"
+msgid "Landscape Wall"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31360"
+msgid "Square Wall"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31361"
+msgid "Landscape Showcase"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31362"
+msgid "Square Showcase"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31363"
+msgid "Big Posters"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31364"
+msgid "Mouse compatibility"
+msgstr ""
+
+#: /1080i/script-script.extendedinfo-DialogVideoInfo.xml
+msgctxt "#31365"
+msgid "Images"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31366"
+msgid "Artwork button downloads all artwork"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31367"
+msgid "Recently Added TV Shows"
+msgstr ""
+
+#: /1080i/script-script.extendedinfo-DialogInfo.xml
+msgctxt "#31368"
+msgid "Tagged Images"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31369"
+msgid "Prefer fanart for landscape widgets"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31370"
+msgid "Banner Wall"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31371"
+msgid "Categories widget text"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31372"
+msgid "Force default menu position"
+msgstr ""
+
+#: /1080i/Includes_Widgets.xml
+msgctxt "#31373"
+msgid "See More"
+msgstr ""
+
+#: /1080i/EventLog.xml
+msgctxt "#31374"
+msgid "Order"
+msgstr ""
+
+#: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
+msgctxt "#31375"
+msgid "Gradients on backing panels"
+msgstr ""
+
+#: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
+msgctxt "#31376"
+msgid "Show the \"See More\" widget item"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31377"
+msgid "Video lyrics"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31378"
+msgid "Genre names in PVR guide"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31379"
+msgid "Display plot overlay after a delay"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31380"
+msgid "Untitled"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31381"
+msgid "Last Played Channels"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31382"
+msgid "Active Recordings"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31383"
+msgid "Grouped Active Recordings"
+msgstr ""
+
+#: /shortcuts/overrides.xml
+msgctxt "#31384"
+msgid "Grouped Deleted Recordings"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31385"
+msgid "Episode List"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31386"
+msgid "Auto close OSD controls after a delay (in seconds)"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31387"
+msgid "Splash screen image"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31388"
+msgid "Download All Artwork"
+msgstr ""
+
+#: /1080i/DialogVideoInfo.xml
+msgctxt "#31389"
+msgid "Select Artwork"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31390"
+msgid "Pressing up from top menu shows fanart / plot"
+msgstr ""
+
+#: /1080i/Includes_Topbar.xml
+msgctxt "#31391"
+msgid "Page"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31392"
+msgid "Sort Letter"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31393"
+msgid "Show media flags instead of ratings in library views"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31394"
+msgid "Monochrome flags"
+msgstr ""
+
+#: /1080i/Includes_Items.xml
+msgctxt "#31395"
+msgid "Music Playlist"
+msgstr ""
+
+#: /1080i/Includes_Items.xml
+msgctxt "#31396"
+msgid "Video Playlist"
+msgstr ""
+
+#: /1080i/Includes_View_Posters.xml
+msgctxt "#31397"
+msgid "Square Wall Large"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31398"
+msgid "Force extendedinfo to open when pressing info"
+msgstr ""
+
+#: /1080i/Includes_Labels.xml
+msgctxt "#31399"
+msgid "Text"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31400"
+msgid "Movies by Director"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31401"
+msgid "Next Up Episodes"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31402"
+msgid "Similar Movies"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31403"
+msgid "Similar Tv Shows"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31404"
+msgid "Movies from Studio"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31405"
+msgid "Extrafanart"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31406"
+msgid "Extras / Special Features"
+msgstr ""
+
+#: /1080i/Custom_1119_EnableInfoLists.xml
+msgctxt "#31407"
+msgid "Enable / disable info dialog lists"
+msgstr ""
+
+#: /1080i/Includes_Items.xml
+msgctxt "#31408"
+msgid "Subtitle settings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31409"
+msgid "Subtitles button opens subtitle settings"
+msgstr ""
+
+#: /1080i/SkinSettings.xml
+msgctxt "#31410"
+msgid "Show trailers and special features in the preview window"
+msgstr ""
+
+#: /1080i/Includes_Weather.xml
+msgctxt "#31411"
+msgid "Unavailable"
+msgstr ""

--- a/language/resource.language.en_us/strings.po
+++ b/language/resource.language.en_us/strings.po
@@ -13,1953 +13,1953 @@ msgstr ""
 #: /1080i/Includes_Global.xml
 msgctxt "#31000"
 msgid "Reduced"
-msgstr ""
+msgstr "Reduced"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31001"
 msgid "Revenue"
-msgstr ""
+msgstr "Revenue"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31002"
 msgid "Categories widget"
-msgstr ""
+msgstr "Categories widget"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31003"
 msgid "Current conditions"
-msgstr ""
+msgstr "Current conditions"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31004"
 msgid "Sunset at"
-msgstr ""
+msgstr "Sunset at"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31005"
 msgid "Sunrise at"
-msgstr ""
+msgstr "Sunrise at"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31006"
 msgid "Weather provided by"
-msgstr ""
+msgstr "Weather provided by"
 
 #: /1080i/Includes_Furniture.xml
 msgctxt "#31007"
 msgid "Weather forecast for"
-msgstr ""
+msgstr "Weather forecast for"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31008"
 msgid "Install weather fanart"
-msgstr ""
+msgstr "Install weather fanart"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31009"
 msgid "Complete"
-msgstr ""
+msgstr "Complete"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31010"
 msgid "Weather fanart successfully installed"
-msgstr ""
+msgstr "Weather fanart successfully installed"
 
 #: /1080i/MyWeather.xml
 msgctxt "#31011"
 msgid "Default weather icons"
-msgstr ""
+msgstr "Default weather icons"
 
 #: /1080i/MyWeather.xml
 msgctxt "#31012"
 msgid "Weather fanart installed"
-msgstr ""
+msgstr "Weather fanart installed"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31013"
 msgid "Set weather icons"
-msgstr ""
+msgstr "Set weather icons"
 
 #: /1080i/MyVideoNav.xml
 msgctxt "#31014"
 msgid "Extra fanart"
-msgstr ""
+msgstr "Extra fanart"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31015"
 msgid "Minimal busy loader"
-msgstr ""
+msgstr "Minimal busy loader"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31016"
 msgid "By"
-msgstr ""
+msgstr "By"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31017"
 msgid "Smart Shortcuts"
-msgstr ""
+msgstr "Smart Shortcuts"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31018"
 msgid "Common Shortcut"
-msgstr ""
+msgstr "Common Shortcut"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31019"
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31020"
 msgid "mins"
-msgstr ""
+msgstr "mins"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31021"
-msgid "Colors"
-msgstr ""
+msgid "Colours"
+msgstr "Colors"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31022"
 msgid "Animated artwork"
-msgstr ""
+msgstr "Animated artwork"
 
 #: /1080i/Includes_Statusbar.xml
 msgctxt "#31023"
 msgid "Fullscreen"
-msgstr ""
+msgstr "Fullscreen"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31024"
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Miscellaneous"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31025"
 msgid "From"
-msgstr ""
+msgstr "From"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31026"
 msgid "Alphabet strip"
-msgstr ""
+msgstr "Alphabet strip"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31027"
-msgid "Customize power menu"
-msgstr ""
+msgid "Customise power menu"
+msgstr "Customize power menu"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31028"
 msgid "Reset skin settings to defaults (WARNING: This will reset your home menu to skin defaults)"
-msgstr ""
+msgstr "Reset skin settings to defaults (WARNING: This will reset your home menu to skin defaults)"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31029"
 msgid "Hide Spoilers"
-msgstr ""
+msgstr "Hide Spoilers"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31030"
 msgid "Backup / Restore"
-msgstr ""
+msgstr "Backup / Restore"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31031"
 msgid "Backup skin settings"
-msgstr ""
+msgstr "Backup skin settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31032"
 msgid "Restore skin settings"
-msgstr ""
+msgstr "Restore skin settings"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31033"
 msgid "Audio Settings"
-msgstr ""
+msgstr "Audio Settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31034"
 msgid "Change backup and restore path"
-msgstr ""
+msgstr "Change backup and restore path"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31035"
 msgid "hrs"
-msgstr ""
+msgstr "hrs"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31036"
 msgid "hr"
-msgstr ""
+msgstr "hr"
 
 #: /1080i/DialogSubtitles.xml
 msgctxt "#31037"
 msgid "Download Subtitles"
-msgstr ""
+msgstr "Download Subtitles"
 
 #: /1080i/Includes_View.xml
 msgctxt "#31038"
 msgid "Landscape"
-msgstr ""
+msgstr "Landscape"
 
 #: /1080i/Custom_1117_EnableViews.xml
 msgctxt "#31039"
 msgid "Enable / disable view modes"
-msgstr ""
+msgstr "Enable / disable view modes"
 
 #: /1080i/Custom_1117_EnableViews.xml
 msgctxt "#31040"
 msgid "Poster Showcase"
-msgstr ""
+msgstr "Poster Showcase"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31041"
-msgid "Customize your home menu items, widgets, and backgrounds."
-msgstr ""
+msgid "Customise your home menu items, widgets, and backgrounds."
+msgstr "Customize your home menu items, widgets, and backgrounds."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31042"
 msgid "Wall view text labels"
-msgstr ""
+msgstr "Wall view text labels"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31043"
 msgid "Select Action"
-msgstr ""
+msgstr "Select Action"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31044"
 msgid "Search library for movies staring"
-msgstr ""
+msgstr "Search library for movies staring"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31045"
 msgid "Show extended info about"
-msgstr ""
+msgstr "Show extended info about"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31046"
 msgid "Search library"
-msgstr ""
+msgstr "Search library"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31047"
 msgid "This disables fanart in the library and shows the fallback image instead."
-msgstr ""
+msgstr "This disables fanart in the library and shows the fallback image instead."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31048"
 msgid "Set a fallback image for when no fanart is available."
-msgstr ""
+msgstr "Set a fallback image for when no fanart is available."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31049"
-msgid "Display artist fanart stored from the library database on the music visualization screen."
-msgstr ""
+msgid "Display artist fanart stored from the library database on the music visualisation screen."
+msgstr "Display artist fanart stored from the library database on the music visualization screen."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31050"
-msgid "Use artist slideshow addon to display artist fanart on the music visualization screen."
-msgstr ""
+msgid "Use artist slideshow addon to display artist fanart on the music visualisation screen."
+msgstr "Use artist slideshow addon to display artist fanart on the music visualization screen."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31051"
-msgid "Make the artist fanart slightly transparent so that the music visualization shows through."
-msgstr ""
+msgid "Make the artist fanart slightly transparent so that the music visualisation shows through."
+msgstr "Make the artist fanart slightly transparent so that the music visualization shows through."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31052"
-msgid "Use a pan and zoom effect on the artist fanart in the music visualization."
-msgstr ""
+msgid "Use a pan and zoom effect on the artist fanart in the music visualisation."
+msgstr "Use a pan and zoom effect on the artist fanart in the music visualization."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31053"
 msgid "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
-msgstr ""
+msgstr "Display discart in showcase view types. Available discart overrides logo if both options are enabled."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31054"
 msgid "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
-msgstr ""
+msgstr "Display logo in showcase view types. Available discart overrides logo if both options are enabled."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31055"
 msgid "Use skinhelper to provide animated posters and fanart. These can be downloaded from the context menu."
-msgstr ""
+msgstr "Use skinhelper to provide animated posters and fanart. These can be downloaded from the context menu."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31056"
-msgid "Genre colors in PVR guide"
-msgstr ""
+msgid "Genre colours in PVR guide"
+msgstr "Genre colors in PVR guide"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31057"
 msgid "Use fullscreen PVR guide (hide plot info)"
-msgstr ""
+msgstr "Use fullscreen PVR guide (hide plot info)"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31058"
-msgid "Change the highlight focus color used throughout the skin."
-msgstr ""
+msgid "Change the highlight focus colour used throughout the skin."
+msgstr "Change the highlight focus color used throughout the skin."
 
 #: /1080i/DialogContextMenu.xml
 msgctxt "#31059"
 msgid "Context Menu"
-msgstr ""
+msgstr "Context Menu"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31060"
 msgid "Set music or video playlist that will run when Kodi starts."
-msgstr ""
+msgstr "Set music or video playlist that will run when Kodi starts."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31061"
 msgid "Disable the alphabet strip and always use scrollbars instead."
-msgstr ""
+msgstr "Disable the alphabet strip and always use scrollbars instead."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31062"
 msgid "Disable changing view settings and some settings buttons in information dialogs."
-msgstr ""
+msgstr "Disable changing view settings and some settings buttons in information dialogs."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31063"
 msgid "Change the items displayed in the power menu."
-msgstr ""
+msgstr "Change the items displayed in the power menu."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31064"
 msgid "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
-msgstr ""
+msgstr "Backup your skin settings and home menu shortcuts to a zip file. Useful to migrate settings to a new setup."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31065"
 msgid "Restore your skin settings, shortcuts, and widgets from a backup file."
-msgstr ""
+msgstr "Restore your skin settings, shortcuts, and widgets from a backup file."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31066"
 msgid "Change the location where skin backup files are saved."
-msgstr ""
+msgstr "Change the location where skin backup files are saved."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31067"
 msgid "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
-msgstr ""
+msgstr "Reset all your skin settings, shortcuts, and widgets to default skin settings. This will not change any Kodi system settings."
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31068"
 msgid "Cloud cover"
-msgstr ""
+msgstr "Cloud cover"
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31069"
 msgid "Cloud cover is "
-msgstr ""
+msgstr "Cloud cover is "
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31070"
 msgid "Cloud Cover"
-msgstr ""
+msgstr "Cloud Cover"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31071"
 msgid "IMDB Top250"
-msgstr ""
+msgstr "IMDB Top250"
 
 #: /1080i/DialogButtonMenu.xml
 msgctxt "#31072"
 msgid "Power Menu"
-msgstr ""
+msgstr "Power Menu"
 
 #: /1080i/VideoOSD.xml
 msgctxt "#31073"
 msgid "Recommended Youtube Videos"
-msgstr ""
+msgstr "Recommended Youtube Videos"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31074"
-msgid "Make bottombar transparent"
-msgstr ""
+msgid "Make bottom bar transparent"
+msgstr "Make bottombar transparent"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31075"
-msgid "Apply transparency to bottombar"
-msgstr ""
+msgid "Apply transparency to bottom bar"
+msgstr "Apply transparency to bottombar"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31076"
 msgid "Enable transparency"
-msgstr ""
+msgstr "Enable transparency"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31077"
-msgid "Add slight transparency to the top and bottombars."
-msgstr ""
+msgid "Add slight transparency to the top and bottom bars."
+msgstr "Add slight transparency to the top and bottombars."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31078"
 msgid "Ended"
-msgstr ""
+msgstr "Ended"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31079"
 msgid "Pause video when opening extended info"
-msgstr ""
+msgstr "Pause video when opening extended info"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31080"
 msgid "Artwork button downloads all available artwork (as specified in artwork downloader settings)"
-msgstr ""
+msgstr "Artwork button downloads all available artwork (as specified in artwork downloader settings)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31081"
 msgid "Hide plot"
-msgstr ""
+msgstr "Hide plot"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31082"
 msgid "Video process information"
-msgstr ""
+msgstr "Video process information"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31083"
 msgid "Framerate"
-msgstr ""
+msgstr "Framerate"
 
 #: /1080i/DialogPlayerProcessInfo.xml
 msgctxt "#31084"
 msgid "Aspect Ratio"
-msgstr ""
+msgstr "Aspect Ratio"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31085"
 msgid "Codec Info"
-msgstr ""
+msgstr "Codec Info"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31086"
 msgid "Extended Info"
-msgstr ""
+msgstr "Extended Info"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31087"
-msgid "Color overlay effect"
-msgstr ""
+msgid "Colour overlay effect"
+msgstr "Color overlay effect"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31088"
 msgid "Scrolling text effect"
-msgstr ""
+msgstr "Scrolling text effect"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31089"
 msgid "Position context menu based on the focused item"
-msgstr ""
+msgstr "Position context menu based on the focused item"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31090"
 msgid "Display duration format as X HRS XX MINS"
-msgstr ""
+msgstr "Display duration format as X HRS XX MINS"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31091"
 msgid "Prefer list view for seasons"
-msgstr ""
+msgstr "Prefer list view for seasons"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31092"
 msgid "System Name"
-msgstr ""
+msgstr "System Name"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31093"
 msgid "Gateway Address"
-msgstr ""
+msgstr "Gateway Address"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31094"
 msgid "Network and Storage"
-msgstr ""
+msgstr "Network and Storage"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31095"
 msgid "Video Encoder"
-msgstr ""
+msgstr "Video Encoder"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31096"
 msgid "Memory"
-msgstr ""
+msgstr "Memory"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31097"
 msgid "Fan Speed"
-msgstr ""
+msgstr "Fan Speed"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31098"
 msgid "CPU Info"
-msgstr ""
+msgstr "CPU Info"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31099"
 msgid "CPU Usage"
-msgstr ""
+msgstr "CPU Usage"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31100"
 msgid "Processor, Memory, and Video"
-msgstr ""
+msgstr "Processor, Memory, and Video"
 
 msgctxt "#31101"
 msgid "items"
-msgstr ""
+msgstr "items"
 
 msgctxt "#31102"
 msgid "min"
-msgstr ""
+msgstr "min"
 
 msgctxt "#31103"
 msgid "Live TV"
-msgstr ""
+msgstr "Live TV"
 
 msgctxt "#31104"
 msgid "Used Memory"
-msgstr ""
+msgstr "Used Memory"
 
 msgctxt "#31105"
 msgid "Spotlight"
-msgstr ""
+msgstr "Spotlight"
 
 msgctxt "#31106"
 msgid "Ends "
-msgstr ""
+msgstr "Ends "
 
 msgctxt "#31107"
 msgid "Video Stream"
-msgstr ""
+msgstr "Video Stream"
 
 msgctxt "#31108"
 msgid "Current Menu"
-msgstr ""
+msgstr "Current Menu"
 
 msgctxt "#31109"
-msgid "Customize home menu"
-msgstr ""
+msgid "Customise home menu"
+msgstr "Customize home menu"
 
 msgctxt "#31110"
 msgid "Background"
-msgstr ""
+msgstr "Background"
 
 msgctxt "#31111"
 msgid "Display now playing video in the background"
-msgstr ""
+msgstr "Display now playing video in the background"
 
 msgctxt "#31112"
 msgid "Submenu"
-msgstr ""
+msgstr "Submenu"
 
 msgctxt "#31113"
 msgid "No Timer"
-msgstr ""
+msgstr "No Timer"
 
 msgctxt "#31114"
 msgid "Now Playing"
-msgstr ""
+msgstr "Now Playing"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31115"
 msgid "Recommended"
-msgstr ""
+msgstr "Recommended"
 
 msgctxt "#31116"
 msgid "DVD Menu"
-msgstr ""
+msgstr "DVD Menu"
 
 msgctxt "#31117"
 msgid "3D Mode"
-msgstr ""
+msgstr "3D Mode"
 
 msgctxt "#31118"
 msgid "Artist slideshow"
-msgstr ""
+msgstr "Artist slideshow"
 
 msgctxt "#31119"
-msgid "Visualization behind slideshow"
-msgstr ""
+msgid "Visualisation behind slideshow"
+msgstr "Visualization behind slideshow"
 
 msgctxt "#31120"
 msgid "Animate artist slideshow"
-msgstr ""
+msgstr "Animate artist slideshow"
 
 msgctxt "#31121"
 msgid "Fanart"
-msgstr ""
+msgstr "Fanart"
 
 msgctxt "#31122"
 msgid "Ongoing Episodes"
-msgstr ""
+msgstr "Ongoing Episodes"
 
 msgctxt "#31123"
 msgid "Resumable Movies"
-msgstr ""
+msgstr "Resumable Movies"
 
 msgctxt "#31124"
 msgid "Recent Movies"
-msgstr ""
+msgstr "Recent Movies"
 
 msgctxt "#31125"
 msgid "Recent Episodes"
-msgstr ""
+msgstr "Recent Episodes"
 
 msgctxt "#31126"
 msgid "Episodes Spotlight"
-msgstr ""
+msgstr "Episodes Spotlight"
 
 msgctxt "#31127"
 msgid "Movies Spotlight"
-msgstr ""
+msgstr "Movies Spotlight"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31128"
 msgid "Allow scrolling through items when in full fanart mode"
-msgstr ""
+msgstr "Allow scrolling through items when in full fanart mode"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31129"
 msgid "Enable full fanart mode"
-msgstr ""
+msgstr "Enable full fanart mode"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31130"
 msgid "Media flags"
-msgstr ""
+msgstr "Media flags"
 
 #: /1080i/MusicOSD.xml
 msgctxt "#31131"
-msgid "Color overlay"
-msgstr ""
+msgid "Colour overlay"
+msgstr "Color overlay"
 
 msgctxt "#31132"
 msgid "Reset home menu shortcuts to defaults"
-msgstr ""
+msgstr "Reset home menu shortcuts to defaults"
 
 msgctxt "#31133"
 msgid "Hide watched"
-msgstr ""
+msgstr "Hide watched"
 
 msgctxt "#31134"
 msgid "Trending Movies"
-msgstr ""
+msgstr "Trending Movies"
 
 msgctxt "#31135"
 msgid "Trending Shows"
-msgstr ""
+msgstr "Trending Shows"
 
 msgctxt "#31136"
 msgid "Airing Shows"
-msgstr ""
+msgstr "Airing Shows"
 
 msgctxt "#31137"
 msgid "Premiering Shows"
-msgstr ""
+msgstr "Premiering Shows"
 
 msgctxt "#31138"
 msgid "Content Loading"
-msgstr ""
+msgstr "Content Loading"
 
 msgctxt "#31139"
 msgid "Box Office"
-msgstr ""
+msgstr "Box Office"
 
 msgctxt "#31140"
 msgid "Budget"
-msgstr ""
+msgstr "Budget"
 
 msgctxt "#31141"
 msgid "Youtube"
-msgstr ""
+msgstr "Youtube"
 
 #: /1080i/MusicOSD.xml
 msgctxt "#31142"
 msgid "Scrolling text"
-msgstr ""
+msgstr "Scrolling text"
 
 msgctxt "#31143"
 msgid "Set weather fanart"
-msgstr ""
+msgstr "Set weather fanart"
 
 msgctxt "#31144"
 msgid "Edit Widgets"
-msgstr ""
+msgstr "Edit Widgets"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31145"
 msgid "Display poster and plot when a video is paused"
-msgstr ""
+msgstr "Display poster and plot when a video is paused"
 
 msgctxt "#31146"
 msgid "Animate fanart"
-msgstr ""
+msgstr "Animate fanart"
 
 msgctxt "#31147"
 msgid "Extra Info"
-msgstr ""
+msgstr "Extra Info"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31148"
 msgid "Hide artwork"
-msgstr ""
+msgstr "Hide artwork"
 
 msgctxt "#31149"
 msgid "Replace widget fanart with background"
-msgstr ""
+msgstr "Replace widget fanart with background"
 
 msgctxt "#31150"
 msgid "Set fallback image"
-msgstr ""
+msgstr "Set fallback image"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31151"
 msgid "Hide tvshow labels"
-msgstr ""
+msgstr "Hide tvshow labels"
 
 msgctxt "#31152"
 msgid "Furniture"
-msgstr ""
+msgstr "Furniture"
 
 #: /1080i/Includes_Statusbar.xml
 msgctxt "#31153"
 msgid "Sort by:"
-msgstr ""
+msgstr "Sort by:"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31154"
 msgid "Only use blur in the info dialog"
-msgstr ""
+msgstr "Only use blur in the info dialog"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31155"
 msgid "Disable the bounce in animation when scrolling between items."
-msgstr ""
+msgstr "Disable the bounce in animation when scrolling between items."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31156"
-msgid "Apply a color changing overlay effect to music visualization background."
-msgstr ""
+msgid "Apply a colour changing overlay effect to music visualisation background."
+msgstr "Apply a color changing overlay effect to music visualization background."
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31157"
-msgid "A scrolling text effect showing artist, album and song info overlaid on the music visualization background."
-msgstr ""
+msgid "A scrolling text effect showing artist, album and song info overlaid on the music visualisation background."
+msgstr "A scrolling text effect showing artist, album and song info overlaid on the music visualization background."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31158"
-msgid "Automatically open visualization after starting a song"
-msgstr ""
+msgid "Automatically open visualisation after starting a song"
+msgstr "Automatically open visualization after starting a song"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31159"
 msgid "Video Sources"
-msgstr ""
+msgstr "Video Sources"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31160"
 msgid "Music sources"
-msgstr ""
+msgstr "Music sources"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31161"
 msgid "Showcase"
-msgstr ""
+msgstr "Showcase"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31162"
 msgid "Categories"
-msgstr ""
+msgstr "Categories"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31163"
 msgid "Submenu Items"
-msgstr ""
+msgstr "Submenu Items"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31164"
 msgid "Info List"
-msgstr ""
+msgstr "Info List"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31165"
 msgid "TV recordings"
-msgstr ""
+msgstr "TV recordings"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31166"
 msgid "TV timers"
-msgstr ""
+msgstr "TV timers"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31167"
 msgid "Square list"
-msgstr ""
+msgstr "Square list"
 
 msgctxt "#31168"
 msgid "Startup video or music playlist"
-msgstr ""
+msgstr "Startup video or music playlist"
 
 msgctxt "#31169"
 msgid "Extras"
-msgstr ""
+msgstr "Extras"
 
 msgctxt "#31170"
 msgid "Cinema Experience"
-msgstr ""
+msgstr "Cinema Experience"
 
 msgctxt "#31171"
 msgid "Video Extras"
-msgstr ""
+msgstr "Video Extras"
 
 msgctxt "#31172"
-msgid "Display music visualization in the background"
-msgstr ""
+msgid "Display music visualisation in the background"
+msgstr "Display music visualization in the background"
 
 msgctxt "#31173"
 msgid "Recently added"
-msgstr ""
+msgstr "Recently added"
 
 msgctxt "#31174"
 msgid "Recently played"
-msgstr ""
+msgstr "Recently played"
 
 msgctxt "#31175"
 msgid "Play random"
-msgstr ""
+msgstr "Play random"
 
 msgctxt "#31176"
 msgid "Delete Settings Shortcut"
-msgstr ""
+msgstr "Delete Settings Shortcut"
 
 msgctxt "#31177"
 msgid "Are you sure you want to remove the settings shortcut?[CR]Please ensure that you have an alternative method of accessing settings before you remove this shortcut."
-msgstr ""
+msgstr "Are you sure you want to remove the settings shortcut?[CR]Please ensure that you have an alternative method of accessing settings before you remove this shortcut."
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31178"
 msgid "Show extended info"
-msgstr ""
+msgstr "Show extended info"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31179"
 msgid "Lock view"
-msgstr ""
+msgstr "Lock view"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31180"
 msgid "Unlock view"
-msgstr ""
+msgstr "Unlock view"
 
 msgctxt "#31181"
 msgid "Select icon"
-msgstr ""
+msgstr "Select icon"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31182"
 msgid "Additional Widgets"
-msgstr ""
+msgstr "Additional Widgets"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31183"
 msgid "Default Widgets"
-msgstr ""
+msgstr "Default Widgets"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31184"
 msgid "Recently played movies"
-msgstr ""
+msgstr "Recently played movies"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31185"
 msgid "Recently Added Movies"
-msgstr ""
+msgstr "Recently Added Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31186"
 msgid "Display OSD submenu"
-msgstr ""
+msgstr "Display OSD submenu"
 
 msgctxt "#31187"
 msgid "Random Albums"
-msgstr ""
+msgstr "Random Albums"
 
 msgctxt "#31188"
 msgid "Recent Albums"
-msgstr ""
+msgstr "Recent Albums"
 
 msgctxt "#31189"
 msgid "Recommended Albums"
-msgstr ""
+msgstr "Recommended Albums"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31190"
 msgid "Recently Played Movies"
-msgstr ""
+msgstr "Recently Played Movies"
 
 msgctxt "#31191"
 msgid "Directed by"
-msgstr ""
+msgstr "Directed by"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31192"
 msgid "Focus bounce animation"
-msgstr ""
+msgstr "Focus bounce animation"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31193"
-msgid "Reset colors to default"
-msgstr ""
+msgid "Reset colours to default"
+msgstr "Reset colors to default"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31194"
 msgid "Recently Played TV Shows"
-msgstr ""
+msgstr "Recently Played TV Shows"
 
 msgctxt "#31195"
 msgid "Reload Skin"
-msgstr ""
+msgstr "Reload Skin"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31196"
 msgid "In Progress TV Shows"
-msgstr ""
+msgstr "In Progress TV Shows"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31197"
 msgid "Save Changes"
-msgstr ""
+msgstr "Save Changes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31198"
 msgid "Recently Played Episodes"
-msgstr ""
+msgstr "Recently Played Episodes"
 
 msgctxt "#31199"
 msgid "Kiosk mode"
-msgstr ""
+msgstr "Kiosk mode"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31200"
 msgid "Random Movies"
-msgstr ""
+msgstr "Random Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31201"
 msgid "Pressing info only displays seekbar (hides poster and plot)"
-msgstr ""
+msgstr "Pressing info only displays seekbar (hides poster and plot)"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31202"
 msgid "Random Episodes"
-msgstr ""
+msgstr "Random Episodes"
 
 msgctxt "#31203"
 msgid "Artwork"
-msgstr ""
+msgstr "Artwork"
 
 msgctxt "#31204"
 msgid "Similar to"
-msgstr ""
+msgstr "Similar to"
 
 msgctxt "#31205"
 msgid "Released by"
-msgstr ""
+msgstr "Released by"
 
 msgctxt "#31206"
 msgid "Similar"
-msgstr ""
+msgstr "Similar"
 
 msgctxt "#31207"
 msgid "themoviedb.org"
-msgstr ""
+msgstr "themoviedb.org"
 
 msgctxt "#31208"
 msgid "In Cinemas"
-msgstr ""
+msgstr "In Cinemas"
 
 msgctxt "#31209"
 msgid "Upcoming"
-msgstr ""
+msgstr "Upcoming"
 
 msgctxt "#31210"
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgctxt "#31211"
 msgid "Top-Rated"
-msgstr ""
+msgstr "Top-Rated"
 
 msgctxt "#31212"
 msgid "Airing"
-msgstr ""
+msgstr "Airing"
 
 msgctxt "#31213"
 msgid "Today"
-msgstr ""
+msgstr "Today"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31214"
 msgid "Recently Added Episodes"
-msgstr ""
+msgstr "Recently Added Episodes"
 
 msgctxt "#31215"
 msgid "Unwatched"
-msgstr ""
+msgstr "Unwatched"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31216"
 msgid "In Progress Movies"
-msgstr ""
+msgstr "In Progress Movies"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31217"
 msgid "Change location"
-msgstr ""
+msgstr "Change location"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31218"
 msgid "In Progress Episodes"
-msgstr ""
+msgstr "In Progress Episodes"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31219"
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
 msgctxt "#31220"
 msgid "Next Aired"
-msgstr ""
+msgstr "Next Aired"
 
 #: /1080i/script-nextup-notification-PostPlayInfo.xml
 msgctxt "#31221"
 msgid "Next Up"
-msgstr ""
+msgstr "Next Up"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31222"
 msgid "Top-Rated TV Shows"
-msgstr ""
+msgstr "Top-Rated TV Shows"
 
 msgctxt "#31223"
 msgid "Upcoming Movies"
-msgstr ""
+msgstr "Upcoming Movies"
 
 msgctxt "#31224"
 msgid "Popular Movies"
-msgstr ""
+msgstr "Popular Movies"
 
 msgctxt "#31225"
 msgid "Top-Rated Movies"
-msgstr ""
+msgstr "Top-Rated Movies"
 
 msgctxt "#31226"
 msgid "Popular TV Shows"
-msgstr ""
+msgstr "Popular TV Shows"
 
 msgctxt "#31227"
 msgid "Top-Rated TV Shows"
-msgstr ""
+msgstr "Top-Rated TV Shows"
 
 msgctxt "#31228"
 msgid "On-Air TV Shows"
-msgstr ""
+msgstr "On-Air TV Shows"
 
 msgctxt "#31229"
 msgid "TV Shows Airing Today"
-msgstr ""
+msgstr "TV Shows Airing Today"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31230"
 msgid "Top-Rated Episodes"
-msgstr ""
+msgstr "Top-Rated Episodes"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31231"
 msgid "Lovefilm"
-msgstr ""
+msgstr "Lovefilm"
 
 msgctxt "#31232"
 msgid "Reset path"
-msgstr ""
+msgstr "Reset path"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31233"
 msgid "Random TV Shows"
-msgstr ""
+msgstr "Random TV Shows"
 
 #: /1080i/SettingsProfile.xml
 msgctxt "#31234"
-msgid "Customize your user profiles and enable/disable the login screen."
-msgstr ""
+msgid "Customise your user profiles and enable/disable the login screen."
+msgstr "Customize your user profiles and enable/disable the login screen."
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31235"
 msgid "Set sorting (default$COMMA year$COMMA rating$COMMA lastplayed$COMMA dateadded$COMMA etc.)"
-msgstr ""
+msgstr "Set sorting (default$COMMA year$COMMA rating$COMMA lastplayed$COMMA dateadded$COMMA etc.)"
 
 msgctxt "#31236"
 msgid "Now playing..."
-msgstr ""
+msgstr "Now playing..."
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31237"
 msgid "Sort"
-msgstr ""
+msgstr "Sort"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31238"
 msgid "Recently Added Albums"
-msgstr ""
+msgstr "Recently Added Albums"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31239"
 msgid "Direction"
-msgstr ""
+msgstr "Direction"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31240"
 msgid "Aspect"
-msgstr ""
+msgstr "Aspect"
 
 msgctxt "#31241"
 msgid "Additional info"
-msgstr ""
+msgstr "Additional info"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31242"
 msgid "Recently Played Albums"
-msgstr ""
+msgstr "Recently Played Albums"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31243"
 msgid "Top 100 Albums"
-msgstr ""
+msgstr "Top 100 Albums"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31244"
 msgid "Select Widget"
-msgstr ""
+msgstr "Select Widget"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31245"
-msgid "Customize"
-msgstr ""
+msgid "Customise"
+msgstr "Customize"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31246"
-msgid "Press right to customize widgets"
-msgstr ""
+msgid "Press right to customise widgets"
+msgstr "Press right to customize widgets"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31247"
 msgid "Widgets"
-msgstr ""
+msgstr "Widgets"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31248"
 msgid "Edit Shortcuts"
-msgstr ""
+msgstr "Edit Shortcuts"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31249"
-msgid "Press right to customize shortcuts"
-msgstr ""
+msgid "Press right to customise shortcuts"
+msgstr "Press right to customize shortcuts"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31250"
-msgid "Gradient color"
-msgstr ""
+msgid "Gradient colour"
+msgstr "Gradient color"
 
 msgctxt "#31251"
 msgid "Weather Fanart"
-msgstr ""
+msgstr "Weather Fanart"
 
 msgctxt "#31252"
 msgid "Weather Forecast"
-msgstr ""
+msgstr "Weather Forecast"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31253"
 msgid "Use a larger font for the progress bar"
-msgstr ""
+msgstr "Use a larger font for the progress bar"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31254"
 msgid "If you are having difficulties with widgets or home menu items not displaying correctly please make sure that you press the \"save changes\" button to ensure that your shortcuts and widgets are set."
-msgstr ""
+msgstr "If you are having difficulties with widgets or home menu items not displaying correctly please make sure that you press the \"save changes\" button to ensure that your shortcuts and widgets are set."
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31255"
 msgid "Generate landscape art"
-msgstr ""
+msgstr "Generate landscape art"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31256"
 msgid "Display artwork"
-msgstr ""
+msgstr "Display artwork"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31257"
 msgid "Movie Genres"
-msgstr ""
+msgstr "Movie Genres"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31258"
 msgid "Clearart with seekbar"
-msgstr ""
+msgstr "Clearart with seekbar"
 
 msgctxt "#31259"
 msgid "Extra fanart"
-msgstr ""
+msgstr "Extra fanart"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31260"
 msgid "Movie Sets"
-msgstr ""
+msgstr "Movie Sets"
 
 msgctxt "#31261"
 msgid "Widget aspect"
-msgstr ""
+msgstr "Widget aspect"
 
 msgctxt "#31262"
 msgid "Poster"
-msgstr ""
+msgstr "Poster"
 
 msgctxt "#31263"
 msgid "Square"
-msgstr ""
+msgstr "Square"
 
 msgctxt "#31264"
 msgid "Thumbnail"
-msgstr ""
+msgstr "Thumbnail"
 
 msgctxt "#31265"
 msgid "Fanart"
-msgstr ""
+msgstr "Fanart"
 
 msgctxt "#31266"
 msgid "Widget"
-msgstr ""
+msgstr "Widget"
 
 msgctxt "#31267"
 msgid "Action"
-msgstr ""
+msgstr "Action"
 
 msgctxt "#31268"
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 msgctxt "#31269"
 msgid "Fallback widget"
-msgstr ""
+msgstr "Fallback widget"
 
 msgctxt "#31270"
 msgid "Video / Music OSD"
-msgstr ""
+msgstr "Video / Music OSD"
 
 msgctxt "#31271"
 msgid "Single Image"
-msgstr ""
+msgstr "Single Image"
 
 msgctxt "#31272"
 msgid "Multi Image"
-msgstr ""
+msgstr "Multi Image"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31273"
-msgid "Background overlay color"
-msgstr ""
+msgid "Background overlay colour"
+msgstr "Background overlay color"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31274"
 msgid "TvShow Genres"
-msgstr ""
+msgstr "TvShow Genres"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31275"
 msgid "Blur fanart"
-msgstr ""
+msgstr "Blur fanart"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31276"
 msgid "IMDB Top 250 Movies"
-msgstr ""
+msgstr "IMDB Top 250 Movies"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31277"
 msgid "Animations"
-msgstr ""
+msgstr "Animations"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31278"
 msgid "Unwatched Movies"
-msgstr ""
+msgstr "Unwatched Movies"
 
 msgctxt "#31279"
 msgid "Video decoder"
-msgstr ""
+msgstr "Video decoder"
 
 msgctxt "#31280"
 msgid "Pixel format"
-msgstr ""
+msgstr "Pixel format"
 
 msgctxt "#31281"
 msgid "by"
-msgstr ""
+msgstr "by"
 
 msgctxt "#31282"
 msgid "on"
-msgstr ""
+msgstr "on"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31283"
 msgid "Unwatched Episodes"
-msgstr ""
+msgstr "Unwatched Episodes"
 
 #: MPAA Rating
 msgctxt "#31284"
 msgid "Classification"
-msgstr ""
+msgstr "Classification"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31285"
 msgid "Extended info"
-msgstr ""
+msgstr "Extended info"
 
 msgctxt "#31286"
-msgid "Highlight color"
-msgstr ""
+msgid "Highlight colour"
+msgstr "Highlight color"
 
 msgctxt "#31287"
 msgid "Reset to default"
-msgstr ""
+msgstr "Reset to default"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31288"
-msgid "Match highlight colors with the poster"
-msgstr ""
+msgid "Match highlight colours with the poster"
+msgstr "Match highlight colors with the poster"
 
 msgctxt "#31289"
 msgid "Awards"
-msgstr ""
+msgstr "Awards"
 
 msgctxt "#31290"
 msgid "Consensus"
-msgstr ""
+msgstr "Consensus"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31291"
 msgid "Landscape widget text"
-msgstr ""
+msgstr "Landscape widget text"
 
 #: /1080i/DialogBusy.xml
 msgctxt "#31292"
 msgid "Kodi is busy$COMMA one moment, please"
-msgstr ""
+msgstr "Kodi is busy$COMMA one moment, please"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31293"
 msgid "Skin Helper Widgets"
-msgstr ""
+msgstr "Skin Helper Widgets"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31294"
 msgid "PVR / Live TV"
-msgstr ""
+msgstr "PVR / Live TV"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31295"
 msgid "Random Artists"
-msgstr ""
+msgstr "Random Artists"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31296"
 msgid "Movie Nodes"
-msgstr ""
+msgstr "Movie Nodes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31297"
 msgid "TvShow Nodes"
-msgstr ""
+msgstr "TvShow Nodes"
 
 #: /1080i/Includes_View_List.xml
 msgctxt "#31298"
 msgid "Media Info"
-msgstr ""
+msgstr "Media Info"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31299"
 msgid "Premiered"
-msgstr ""
+msgstr "Premiered"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31300"
 msgid "Music Nodes"
-msgstr ""
+msgstr "Music Nodes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31301"
 msgid "TV Shows"
-msgstr ""
+msgstr "TV Shows"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31302"
 msgid "Music Sources"
-msgstr ""
+msgstr "Music Sources"
 
 #: /1080i/DialogAddonInfo.xml
 msgctxt "#31303"
 msgid "Latest Changes"
-msgstr ""
+msgstr "Latest Changes"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31304"
 msgid "Picture Sources"
-msgstr ""
+msgstr "Picture Sources"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31305"
-msgid "Color cycling"
-msgstr ""
+msgid "Colour cycling"
+msgstr "Color cycling"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31306"
 msgid "Special Features"
-msgstr ""
+msgstr "Special Features"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31307"
 msgid "Prefer plot outline"
-msgstr ""
+msgstr "Prefer plot outline"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31308"
 msgid "Player"
-msgstr ""
+msgstr "Player"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31309"
 msgid "Blur effect type"
-msgstr ""
+msgstr "Blur effect type"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31310"
 msgid "User rating"
-msgstr ""
+msgstr "User rating"
 
 #: /1080i/Includes_OSD.xml
 msgctxt "#31311"
 msgid "Rate Song"
-msgstr ""
+msgstr "Rate Song"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31312"
 msgid "Enable / disable ratings"
-msgstr ""
+msgstr "Enable / disable ratings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31313"
 msgid "Background transparency"
-msgstr ""
+msgstr "Background transparency"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31314"
 msgid "Automatically display music video info at the beginning and end of a clip"
-msgstr ""
+msgstr "Automatically display music video info at the beginning and end of a clip"
 
 #: /1080i/Includes_Home.xml
 msgctxt "#31315"
 msgid "CinemaVision"
-msgstr ""
+msgstr "CinemaVision"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31316"
 msgid "Increased"
-msgstr ""
+msgstr "Increased"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31317"
 msgid "Watched indicators"
-msgstr ""
+msgstr "Watched indicators"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31318"
 msgid "Shadows"
-msgstr ""
+msgstr "Shadows"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31319"
 msgid "Indicator style"
-msgstr ""
+msgstr "Indicator style"
 
 #: /1080i/script-skinshortcuts.xml
 msgctxt "#31320"
 msgid "Important"
-msgstr ""
+msgstr "Important"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31321"
 msgid "Reset to defaults"
-msgstr ""
+msgstr "Reset to defaults"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31322"
 msgid "Image quality changes the resolution of the generated image. Better quality images take longer to process. Quality changes can alter the intensity of the effect in addition to other effect settings. The blend setting will blend the effect with the original image$COMMA with a value of 100 showing the full image effect."
-msgstr ""
+msgstr "Image quality changes the resolution of the generated image. Better quality images take longer to process. Quality changes can alter the intensity of the effect in addition to other effect settings. The blend setting will blend the effect with the original image$COMMA with a value of 100 showing the full image effect."
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31323"
 msgid "Blend"
-msgstr ""
+msgstr "Blend"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31324"
 msgid "Bitsize"
-msgstr ""
+msgstr "Bitsize"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31325"
 msgid "Pixel size"
-msgstr ""
+msgstr "Pixel size"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31326"
 msgid "Blur radius"
-msgstr ""
+msgstr "Blur radius"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31327"
 msgid "Image quality"
-msgstr ""
+msgstr "Image quality"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31328"
 msgid "Highest"
-msgstr ""
+msgstr "Highest"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31329"
 msgid "Colorbox Advanced Settings"
-msgstr ""
+msgstr "Colorbox Advanced Settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31330"
 msgid "Advanced settings for colorbox (blur settings)"
-msgstr ""
+msgstr "Advanced settings for colorbox (blur settings)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31331"
 msgid "Icon only mode"
-msgstr ""
+msgstr "Icon only mode"
 
 #: /1080i/Custom_1116_ColorBoxAdvancedSettings.xml
 msgctxt "#31332"
 msgid "Change image"
-msgstr ""
+msgstr "Change image"
 
 #: /1080i/script-globalsearch-main.xml
 msgctxt "#31333"
 msgid "Programmes"
-msgstr ""
+msgstr "Programmes"
 
 #: /1080i/Includes_Object.xml
 msgctxt "#31334"
 msgid "Alphabet strip is not available for this content"
-msgstr ""
+msgstr "Alphabet strip is not available for this content"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31335"
-msgid "Match background overlay color with the poster"
-msgstr ""
+msgid "Match background overlay colour with the poster"
+msgstr "Match background overlay color with the poster"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31336"
 msgid "Background overlay"
-msgstr ""
+msgstr "Background overlay"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31337"
 msgid "Light"
-msgstr ""
+msgstr "Light"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31338"
 msgid "Background vignette"
-msgstr ""
+msgstr "Background vignette"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31339"
 msgid "Effects"
-msgstr ""
+msgstr "Effects"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31340"
 msgid "Match poster"
-msgstr ""
+msgstr "Match poster"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31341"
 msgid "Dark"
-msgstr ""
+msgstr "Dark"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31342"
 msgid "Widget item limit"
-msgstr ""
+msgstr "Widget item limit"
 
 #: /1080i/Settings.xml
 msgctxt "#31343"
 msgid "PVR"
-msgstr ""
+msgstr "PVR"
 
 #: /1080i/Settings.xml
 msgctxt "#31344"
 msgid "Install from repository or zip"
-msgstr ""
+msgstr "Install from repository or zip"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31345"
 msgid "Event logging"
-msgstr ""
+msgstr "Event logging"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31346"
 msgid "Video OSD"
-msgstr ""
+msgstr "Video OSD"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31347"
 msgid "Music OSD"
-msgstr ""
+msgstr "Music OSD"
 
 #: /1080i/Home.xml
 msgctxt "#31348"
 msgid "Loading Home Menu"
-msgstr ""
+msgstr "Loading Home Menu"
 
 #: /1080i/Startup.xml
 msgctxt "#31349"
-msgid "Initializing Skin"
-msgstr ""
+msgid "Initialising Skin"
+msgstr "Initializing Skin"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31350"
 msgid "Similar to "
-msgstr ""
+msgstr "Similar to "
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31351"
 msgid "Directed by "
-msgstr ""
+msgstr "Directed by "
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31352"
 msgid "Added"
-msgstr ""
+msgstr "Added"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31353"
 msgid "Played"
-msgstr ""
+msgstr "Played"
 
 #: /1080i/DialogMusicInfo.xml
 msgctxt "#31354"
 msgid "Instrument"
-msgstr ""
+msgstr "Instrument"
 
 #: /1080i/DialogMusicInfo.xml
 msgctxt "#31355"
 msgid "Mood"
-msgstr ""
+msgstr "Mood"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31356"
 msgid "Years Old"
-msgstr ""
+msgstr "Years Old"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31357"
 msgid "Crew"
-msgstr ""
+msgstr "Crew"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31358"
 msgid "Poster Wall"
-msgstr ""
+msgstr "Poster Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31359"
 msgid "Landscape Wall"
-msgstr ""
+msgstr "Landscape Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31360"
 msgid "Square Wall"
-msgstr ""
+msgstr "Square Wall"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31361"
 msgid "Landscape Showcase"
-msgstr ""
+msgstr "Landscape Showcase"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31362"
 msgid "Square Showcase"
-msgstr ""
+msgstr "Square Showcase"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31363"
 msgid "Big Posters"
-msgstr ""
+msgstr "Big Posters"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31364"
 msgid "Mouse compatibility"
-msgstr ""
+msgstr "Mouse compatibility"
 
 #: /1080i/script-script.extendedinfo-DialogVideoInfo.xml
 msgctxt "#31365"
 msgid "Images"
-msgstr ""
+msgstr "Images"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31366"
 msgid "Artwork button downloads all artwork"
-msgstr ""
+msgstr "Artwork button downloads all artwork"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31367"
 msgid "Recently Added TV Shows"
-msgstr ""
+msgstr "Recently Added TV Shows"
 
 #: /1080i/script-script.extendedinfo-DialogInfo.xml
 msgctxt "#31368"
 msgid "Tagged Images"
-msgstr ""
+msgstr "Tagged Images"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31369"
 msgid "Prefer fanart for landscape widgets"
-msgstr ""
+msgstr "Prefer fanart for landscape widgets"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31370"
 msgid "Banner Wall"
-msgstr ""
+msgstr "Banner Wall"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31371"
 msgid "Categories widget text"
-msgstr ""
+msgstr "Categories widget text"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31372"
 msgid "Force default menu position"
-msgstr ""
+msgstr "Force default menu position"
 
 #: /1080i/Includes_Widgets.xml
 msgctxt "#31373"
 msgid "See More"
-msgstr ""
+msgstr "See More"
 
 #: /1080i/EventLog.xml
 msgctxt "#31374"
 msgid "Order"
-msgstr ""
+msgstr "Order"
 
 #: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
 msgctxt "#31375"
 msgid "Gradients on backing panels"
-msgstr ""
+msgstr "Gradients on backing panels"
 
 #: /1080i/SkinSettings.xml /1080i/SkinSettings.xml
 msgctxt "#31376"
 msgid "Show the \"See More\" widget item"
-msgstr ""
+msgstr "Show the \"See More\" widget item"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31377"
 msgid "Video lyrics"
-msgstr ""
+msgstr "Video lyrics"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31378"
 msgid "Genre names in PVR guide"
-msgstr ""
+msgstr "Genre names in PVR guide"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31379"
 msgid "Display plot overlay after a delay"
-msgstr ""
+msgstr "Display plot overlay after a delay"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31380"
 msgid "Untitled"
-msgstr ""
+msgstr "Untitled"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31381"
 msgid "Last Played Channels"
-msgstr ""
+msgstr "Last Played Channels"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31382"
 msgid "Active Recordings"
-msgstr ""
+msgstr "Active Recordings"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31383"
 msgid "Grouped Active Recordings"
-msgstr ""
+msgstr "Grouped Active Recordings"
 
 #: /shortcuts/overrides.xml
 msgctxt "#31384"
 msgid "Grouped Deleted Recordings"
-msgstr ""
+msgstr "Grouped Deleted Recordings"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31385"
 msgid "Episode List"
-msgstr ""
+msgstr "Episode List"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31386"
 msgid "Auto close OSD controls after a delay (in seconds)"
-msgstr ""
+msgstr "Auto close OSD controls after a delay (in seconds)"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31387"
 msgid "Splash screen image"
-msgstr ""
+msgstr "Splash screen image"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31388"
 msgid "Download All Artwork"
-msgstr ""
+msgstr "Download All Artwork"
 
 #: /1080i/DialogVideoInfo.xml
 msgctxt "#31389"
 msgid "Select Artwork"
-msgstr ""
+msgstr "Select Artwork"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31390"
 msgid "Pressing up from top menu shows fanart / plot"
-msgstr ""
+msgstr "Pressing up from top menu shows fanart / plot"
 
 #: /1080i/Includes_Topbar.xml
 msgctxt "#31391"
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31392"
 msgid "Sort Letter"
-msgstr ""
+msgstr "Sort Letter"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31393"
 msgid "Show media flags instead of ratings in library views"
-msgstr ""
+msgstr "Show media flags instead of ratings in library views"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31394"
 msgid "Monochrome flags"
-msgstr ""
+msgstr "Monochrome flags"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31395"
 msgid "Music Playlist"
-msgstr ""
+msgstr "Music Playlist"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31396"
 msgid "Video Playlist"
-msgstr ""
+msgstr "Video Playlist"
 
 #: /1080i/Includes_View_Posters.xml
 msgctxt "#31397"
 msgid "Square Wall Large"
-msgstr ""
+msgstr "Square Wall Large"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31398"
 msgid "Force extendedinfo to open when pressing info"
-msgstr ""
+msgstr "Force extendedinfo to open when pressing info"
 
 #: /1080i/Includes_Labels.xml
 msgctxt "#31399"
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31400"
 msgid "Movies by Director"
-msgstr ""
+msgstr "Movies by Director"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31401"
 msgid "Next Up Episodes"
-msgstr ""
+msgstr "Next Up Episodes"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31402"
 msgid "Similar Movies"
-msgstr ""
+msgstr "Similar Movies"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31403"
 msgid "Similar Tv Shows"
-msgstr ""
+msgstr "Similar Tv Shows"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31404"
 msgid "Movies from Studio"
-msgstr ""
+msgstr "Movies from Studio"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31405"
 msgid "Extrafanart"
-msgstr ""
+msgstr "Extrafanart"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31406"
 msgid "Extras / Special Features"
-msgstr ""
+msgstr "Extras / Special Features"
 
 #: /1080i/Custom_1119_EnableInfoLists.xml
 msgctxt "#31407"
 msgid "Enable / disable info dialog lists"
-msgstr ""
+msgstr "Enable / disable info dialog lists"
 
 #: /1080i/Includes_Items.xml
 msgctxt "#31408"
 msgid "Subtitle settings"
-msgstr ""
+msgstr "Subtitle settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31409"
 msgid "Subtitles button opens subtitle settings"
-msgstr ""
+msgstr "Subtitles button opens subtitle settings"
 
 #: /1080i/SkinSettings.xml
 msgctxt "#31410"
 msgid "Show trailers and special features in the preview window"
-msgstr ""
+msgstr "Show trailers and special features in the preview window"
 
 #: /1080i/Includes_Weather.xml
 msgctxt "#31411"
 msgid "Unavailable"
-msgstr ""
+msgstr "Unavailable"


### PR DESCRIPTION
Some changes might be opinionated, let me know if there's anything wrong.

What does "discart" mean in the context of these translations? It's the one word I haven't fixed yet.