### PR TITLE
Fix localized string index for "set"

### DIFF
--- a/1080i/DialogVideoInfo.xml
+++ b/1080i/DialogVideoInfo.xml
@@ -575,7 +575,7 @@
                                 <param name="label2" value="ListItem.Tag" />
                             </include>
                             <include content="Object_VideoInfo_InfoSection">
-                                <param name="label" value="$LOCALIZE[20141]" />
+                                <param name="label" value="$LOCALIZE[36910]" />
                                 <param name="label2" value="ListItem.Set" />
                             </include>
                             <!-- <include content="Object_VideoInfo_InfoSection">


### PR DESCRIPTION
Two strings are referenced as "set" in English but the right string for "set" as "a set of movies" is indexed as [36910](https://github.com/xbmc/repo-resources/blob/leia/resource.language.en_us/resources/strings.po#L15264) (while 20141 is "set" as "initial set-up").