### PR TITLE
Add posters info view

### DIFF
--- a/1080i/Custom_1117_EnableViews.xml
+++ b/1080i/Custom_1117_EnableViews.xml
@@ -132,6 +132,14 @@
                     <selected>!Skin.HasSetting(DisableViewMode.EpisodeList)</selected>
                     <onfocus>SetProperty(Image_Preview,special://skin/extras/backgrounds/viewmodes/episodelist.jpg)</onfocus>
                 </control>
+                <control type="radiobutton" id="9012" description="Poster Info">
+                    <label>$LOCALIZE[31412]</label>
+                    <radioposx>630</radioposx>
+                    <include>Dialog_Standard_ListButton</include>
+                    <onclick>Skin.ToggleSetting(DisableViewMode.PosterInfo)</onclick>
+                    <selected>!Skin.HasSetting(DisableViewMode.PosterInfo)</selected>
+                    <onfocus>SetProperty(Image_Preview,special://skin/extras/backgrounds/viewmodes/posterinfo.jpg)</onfocus><!-- TODO -->
+                </control>
             </control>
         </control>
     </controls>

--- a/1080i/Includes_View.xml
+++ b/1080i/Includes_View.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
 
-    <include name="View_ViewIDs"><views>50,51,52,53,503,54,55,56,57,58,59,500,501,502</views></include>
+    <include name="View_ViewIDs"><views>50,51,52,53,503,54,55,56,57,58,59,500,501,502,504</views></include>
 
     <include name="View_Group">
         <top>view_pad</top>
@@ -53,7 +53,7 @@
                 <include>Animation_FadeIn</include>
                 <include>Animation_FadeOut</include>
                 <include content="Object_Scrollbar_Vert">
-                    <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(52) | Control.IsVisible(53) | Control.IsVisible(54) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502)" />
+                    <param name="visible" value="Control.IsVisible(50) | Control.IsVisible(51) | Control.IsVisible(52) | Control.IsVisible(53) | Control.IsVisible(54) | Control.IsVisible(500) | Control.IsVisible(501) | Control.IsVisible(502) | Control.IsVisible(504)" />
                 </include>
                 <include content="Object_Scrollbar_Horz">
                     <param name="visible" value="Control.IsVisible(55) | Control.IsVisible(56) | Control.IsVisible(57) | Control.IsVisible(58) | Control.IsVisible(59)" />

--- a/1080i/Includes_View_Posters.xml
+++ b/1080i/Includes_View_Posters.xml
@@ -12,6 +12,7 @@
             <include condition="!Skin.HasSetting(DisableViewMode.BigPosters) + [Window.IsVisible(MyPrograms.xml) | Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyGames.xml)]">View_Posters_BigPosters</include>
             <include condition="!Skin.HasSetting(DisableViewMode.Lovefilm) + [Window.IsVisible(MyPrograms.xml) | Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyMusicNav.xml) | Window.IsVisible(MyGames.xml)]">View_Posters_Lovefilm</include>
             <include condition="!Skin.HasSetting(DisableViewMode.EpisodeList) + [Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyMusicNav.xml) | Window.IsVisible(MyGames.xml)]">View_Posters_EpisodeList</include>
+            <include condition="!Skin.HasSetting(DisableViewMode.PosterInfo) + [Window.IsVisible(MyPrograms.xml) | Window.IsVisible(MyVideoNav.xml) | Window.IsVisible(MyMusicNav.xml) | Window.IsVisible(MyGames.xml)]">View_Posters_Info</include>
         </definition>
     </include>
     
@@ -479,6 +480,53 @@
         </control>
     </include>
 
+    <include name="View_Posters_Info">
+        <control type="group">
+            <visible>Control.IsVisible(504)</visible>
+            <control type="group">
+                <include>View_Pad</include>
+                <control type="group">
+                    <left>20</left>
+                    <width>750</width>
+                    <control type="image">
+                        <height>350</height>
+                        <aspectratio scalediffuse="false">scale</aspectratio>
+                        <texture background="true" diffuse="diffuse/landscape.png">$INFO[ListItem.Art(fanart)]</texture>
+                    </control>
+                    <control type="group">
+                        <top>410</top>
+                        <height>650</height>
+                        <include content="Object_Info">
+                            <param name="id" value="504" />
+                            <param name="width" value="710" />
+                            <param name="discart" value="true" />
+                            <param name="hdsd_flag" value="true" />
+                            <param name="plot_height" value="270" />
+                        </include>
+                    </control>
+                </control>
+                <control type="panel" id="504">
+                    <left>770</left>
+                    <right>-10</right>
+                    <bottom>-10</bottom>
+                    <top>-10</top>
+                    <visible>Container.Content(movies) | Container.Content(sets) | Container.Content(tvshows) | Container.Content(seasons) | $EXP[Exp_IsPluginAdvancedLauncher]</visible>
+                    <pagecontrol>60</pagecontrol>
+                    <include>View_NotTheseWindows</include>
+                    <viewtype label="$LOCALIZE[31412]">icon</viewtype>
+                    <include content="View_Forced">
+                        <param name="string" value="$LOCALIZE[31412]" />
+                    </include>
+                    <include content="View_Posters_Layout">
+                        <param name="id" value="504" />
+                        <param name="orientation" value="vertical" />
+                        <param name="posters_small" default="true" />
+                    </include>
+                </control>
+            </control>
+        </control>
+    </include>
+
     <include name="View_Posters_Layout">
         <param name="id" default="51" />
         <param name="setfanart" default="false" />
@@ -487,6 +535,7 @@
         <param name="bottom_offset" default="0" />
         <param name="posters" default="false" />
         <param name="posters_big" default="false" />
+        <param name="posters_small" default="false" />
         <param name="square" default="false" />
         <param name="square_small" default="false" />
         <param name="landscape" default="false" />
@@ -512,7 +561,10 @@
                         <height>380</height>
                         <include>View_Posters_Itemlayout_Artwork</include>
                     </control>
-                    <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
+                    <control type="group">
+                        <top>385</top>
+                        <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
+                    </control>
                 </control>
             </itemlayout>
             <focusedlayout width="260" height="480" condition="$PARAM[posters]">
@@ -531,7 +583,10 @@
                             <include>View_Selectbox</include>
                         </control>
                     </control>
-                    <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
+                    <control type="group">
+                        <top>385</top>
+                        <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
+                    </control>
                 </control>
             </focusedlayout>
             <itemlayout width="400" condition="$PARAM[posters_big]">
@@ -570,6 +625,45 @@
                         <include>View_Posters_Itemlayout_Artwork</include>
                         <visible>Container.OnNext</visible>
                         <animation effect="fade" reversible="false" start="100" end="0" delay="200" time="200">Hidden</animation>
+                    </control>
+                </control>
+            </focusedlayout>
+            <itemlayout width="195" height="385" condition="$PARAM[posters_small]">
+                <control type="group">
+                    <left>view_pad</left>
+                    <right>-view_pad</right>
+                    <top>$PARAM[top_offset]</top>
+                    <bottom>$PARAM[bottom_offset]</bottom>
+                    <control type="group">
+                        <!-- <width>380</width> -->
+                        <height>285</height>
+                        <include>View_Posters_Itemlayout_Artwork</include>
+                    </control>
+                    <control type="group">
+                        <top>290</top>
+                        <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
+                    </control>
+                </control>
+            </itemlayout>
+            <focusedlayout width="195" height="385" condition="$PARAM[posters_small]">
+                <control type="group">
+                    <top>$PARAM[top_offset]</top>
+                    <bottom>$PARAM[bottom_offset]</bottom>
+                    <left>view_pad</left>
+                    <right>-view_pad</right>
+                    <include>Animation_FocusBounce</include>
+                    <control type="group">
+                        <height>285</height>
+                        <include>View_Posters_Focusedlayout_Artwork</include>
+                        <!-- Highlight -->
+                        <control type="group">
+                            <visible>Control.HasFocus($PARAM[id])</visible>
+                            <include>View_Selectbox</include>
+                        </control>
+                    </control>
+                    <control type="group">
+                        <top>290</top>
+                        <include condition="$PARAM[text] + !Skin.HasSetting(DisableViewText)">View_Posters_Text</include>
                     </control>
                 </control>
             </focusedlayout>
@@ -1298,7 +1392,6 @@
             <textcolor>main_fg_100</textcolor>
             <left>10</left>
             <right>10</right>
-            <top>385</top>
         </control>
         <control type="label">
             <label>$INFO[ListItem.Year]</label>
@@ -1308,7 +1401,7 @@
             <textcolor>main_fg_30</textcolor>
             <left>10</left>
             <right>10</right>
-            <top>415</top>
+            <top>30</top>
         </control>
     </include>
     <include name="View_Posters_Itemlayout_Artwork">

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -1963,3 +1963,8 @@ msgstr "Show trailers and special features in the preview window"
 msgctxt "#31411"
 msgid "Unavailable"
 msgstr "Unavailable"
+
+#: /1080i/Custom_1117_EnableViews.xml
+msgctxt "#31412"
+msgid "Poster Info"
+msgstr "Poster Info"


### PR DESCRIPTION
I thought about adding a new "Posters Info" view.
The main idea is to have the left half dedicated to info about the selected item (such as title, year, rating...) and the right half would be similar to the posters view but with smaller posters to have enough space