### PR TITLE
Fix for Artist Slideshow v3

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -9,7 +9,7 @@
 
     <variable name="Image_ArtistFanartVis">
         <value condition="!Skin.HasSetting(ArtistSlideShow.Disabled) + !String.IsEmpty(Window(Home).Property(SkinHelper.Player.Art.ExtraFanArt))">$INFO[Window(Home).Property(SkinHelper.Player.Art.ExtraFanArt)]</value>
-        <value condition="System.HasAddon(script.artistslideshow) + !Skin.HasSetting(ArtistSlideShow.Disabled) + !String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow))">$INFO[Window(Visualisation).Property(ArtistSlideshow)]</value>
+        <value condition="System.HasAddon(script.artistslideshow) + !Skin.HasSetting(ArtistSlideShow.Disabled) + !String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image))">$INFO[Window(Visualisation).Property(ArtistSlideshow.Image)]</value>
         <value condition="[!System.HasAddon(script.artistslideshow) | Skin.HasSetting(ArtistSlideShow.Disabled)] + Skin.HasSetting(musicvis.fanartfallback) + !String.IsEmpty(Player.Art(fanart))">$INFO[Player.Art(fanart)]</value>
         <value>common/null.png</value>
     </variable>


### PR DESCRIPTION
What : "Property(ArtistSlideshow)" replaced with "Property(ArtistSlideshow.Image)"
Why : correction to avoid breaking Artist slideshow add-on
Source : https://forum.kodi.tv/showthread.php?tid=328558&pid=2918140#pid2918140 (tested)
Credit : ray2301 